### PR TITLE
feat: CLI UX overhaul with structured output, color, ghost mascot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ignore: RUSTSEC-2023-0071
 
+  shell-lint:
+    name: Shell Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Syntax check
+        run: bash -n scripts/lib/ui.sh scripts/gcp/*.sh
+      - name: ShellCheck (ui.sh)
+        run: shellcheck scripts/lib/ui.sh
+      - name: ShellCheck (gcp scripts, advisory)
+        run: shellcheck scripts/gcp/*.sh || true
+
   release-gate:
     name: Release Gate (GCP)
     runs-on: ubuntu-latest

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod receipt_verify;
 pub mod storage_protocol;
 pub mod transport_types;
 pub mod types;
+pub mod ui;
 pub mod validation;
 
 // Re-export commonly used types and errors

--- a/common/src/ui/config.rs
+++ b/common/src/ui/config.rs
@@ -1,0 +1,221 @@
+/// Resolved UI configuration for CLI output.
+///
+/// Priority: explicit CLI arg > env var > TTY auto-detect.
+#[derive(Debug, Clone)]
+pub struct UiConfig {
+    /// Emit ANSI color codes.
+    pub color: bool,
+    /// Show ghost mascot.
+    pub mascot: bool,
+}
+
+/// Snapshot of the environment variables relevant to UI configuration.
+///
+/// Extracted into a struct so tests can inject values without mutating
+/// the real process environment (which causes flakes in parallel tests).
+#[derive(Debug, Clone, Default)]
+pub struct EnvState {
+    /// `NO_COLOR` env var is set (any value).
+    pub no_color: bool,
+    /// `CI` env var is set (any value).
+    pub ci: bool,
+    /// Value of `EPHEMERALML_UI` env var (empty if unset).
+    pub ephemeralml_ui: String,
+}
+
+impl EnvState {
+    /// Read the current process environment.
+    pub fn from_env() -> Self {
+        Self {
+            no_color: std::env::var("NO_COLOR").is_ok(),
+            ci: std::env::var("CI").is_ok(),
+            ephemeralml_ui: std::env::var("EPHEMERALML_UI").unwrap_or_default(),
+        }
+    }
+}
+
+impl UiConfig {
+    /// Resolve UI config from CLI flags, environment, and TTY state.
+    ///
+    /// Reads the process environment via `EnvState::from_env()`.
+    /// For tests, use `resolve_with` to inject an `EnvState` directly.
+    ///
+    /// Priority: explicit CLI arg > env var > TTY auto-detect.
+    pub fn resolve(
+        is_tty: bool,
+        plain: bool,
+        no_color: bool,
+        no_mascot: bool,
+        format_json: bool,
+    ) -> Self {
+        Self::resolve_with(
+            is_tty,
+            plain,
+            no_color,
+            no_mascot,
+            format_json,
+            &EnvState::from_env(),
+        )
+    }
+
+    /// Resolve UI config with an explicit `EnvState` (for testing).
+    ///
+    /// Priority: explicit CLI arg > env var > TTY auto-detect.
+    /// - `--plain` or `--format json` disables everything.
+    /// - `--no-color` disables color regardless of env.
+    /// - `EPHEMERALML_UI=rich/plain` overrides TTY auto-detect, but NOT `--no-color`.
+    /// - `NO_COLOR` and `CI` disable color (below CLI flags, same level as env).
+    pub fn resolve_with(
+        is_tty: bool,
+        plain: bool,
+        no_color: bool,
+        no_mascot: bool,
+        format_json: bool,
+        env: &EnvState,
+    ) -> Self {
+        // JSON output or --plain disables all decoration
+        if format_json || plain {
+            return Self {
+                color: false,
+                mascot: false,
+            };
+        }
+
+        // CLI --no-color takes absolute priority over env vars
+        if no_color {
+            return Self {
+                color: false,
+                mascot: false,
+            };
+        }
+
+        // Env vars (lower priority than CLI flags)
+        let color = match env.ephemeralml_ui.as_str() {
+            "rich" => true,
+            "plain" => false,
+            _ => is_tty && !env.no_color && !env.ci,
+        };
+
+        let mascot = color && !no_mascot;
+
+        Self { color, mascot }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_env() -> EnvState {
+        EnvState {
+            no_color: false,
+            ci: false,
+            ephemeralml_ui: String::new(),
+        }
+    }
+
+    #[test]
+    fn tty_with_no_overrides_enables_color() {
+        let cfg = UiConfig::resolve_with(true, false, false, false, false, &empty_env());
+        assert!(cfg.color);
+        assert!(cfg.mascot);
+    }
+
+    #[test]
+    fn non_tty_disables_color() {
+        let cfg = UiConfig::resolve_with(false, false, false, false, false, &empty_env());
+        assert!(!cfg.color);
+        assert!(!cfg.mascot);
+    }
+
+    #[test]
+    fn plain_flag_disables_all() {
+        let cfg = UiConfig::resolve_with(true, true, false, false, false, &empty_env());
+        assert!(!cfg.color);
+        assert!(!cfg.mascot);
+    }
+
+    #[test]
+    fn no_color_flag_disables_color() {
+        let cfg = UiConfig::resolve_with(true, false, true, false, false, &empty_env());
+        assert!(!cfg.color);
+        assert!(!cfg.mascot);
+    }
+
+    #[test]
+    fn no_mascot_flag_disables_mascot_only() {
+        let cfg = UiConfig::resolve_with(true, false, false, true, false, &empty_env());
+        assert!(cfg.color);
+        assert!(!cfg.mascot);
+    }
+
+    #[test]
+    fn format_json_disables_all() {
+        let cfg = UiConfig::resolve_with(true, false, false, false, true, &empty_env());
+        assert!(!cfg.color);
+        assert!(!cfg.mascot);
+    }
+
+    #[test]
+    fn ui_env_rich_forces_color_on_non_tty() {
+        let env = EnvState {
+            ephemeralml_ui: "rich".to_string(),
+            ..empty_env()
+        };
+        let cfg = UiConfig::resolve_with(false, false, false, false, false, &env);
+        assert!(cfg.color);
+    }
+
+    #[test]
+    fn ui_env_plain_forces_no_color() {
+        let env = EnvState {
+            ephemeralml_ui: "plain".to_string(),
+            ..empty_env()
+        };
+        let cfg = UiConfig::resolve_with(true, false, false, false, false, &env);
+        assert!(!cfg.color);
+    }
+
+    #[test]
+    fn no_color_flag_overrides_ui_env_rich() {
+        let env = EnvState {
+            ephemeralml_ui: "rich".to_string(),
+            ..empty_env()
+        };
+        // --no-color flag (CLI) must override EPHEMERALML_UI=rich (env)
+        let cfg = UiConfig::resolve_with(true, false, true, false, false, &env);
+        assert!(!cfg.color);
+        assert!(!cfg.mascot);
+    }
+
+    #[test]
+    fn plain_flag_overrides_ui_env_rich() {
+        let env = EnvState {
+            ephemeralml_ui: "rich".to_string(),
+            ..empty_env()
+        };
+        let cfg = UiConfig::resolve_with(true, true, false, false, false, &env);
+        assert!(!cfg.color);
+        assert!(!cfg.mascot);
+    }
+
+    #[test]
+    fn no_color_env_disables_color() {
+        let env = EnvState {
+            no_color: true,
+            ..empty_env()
+        };
+        let cfg = UiConfig::resolve_with(true, false, false, false, false, &env);
+        assert!(!cfg.color);
+    }
+
+    #[test]
+    fn ci_env_disables_color() {
+        let env = EnvState {
+            ci: true,
+            ..empty_env()
+        };
+        let cfg = UiConfig::resolve_with(true, false, false, false, false, &env);
+        assert!(!cfg.color);
+    }
+}

--- a/common/src/ui/explain.rs
+++ b/common/src/ui/explain.rs
@@ -1,0 +1,94 @@
+use crate::receipt_verify::CheckStatus;
+
+/// Explanation for a failed verification check.
+pub struct CheckExplanation {
+    pub why: &'static str,
+    pub fix: &'static str,
+}
+
+/// Return an explanation for a check if it failed.
+///
+/// Returns `None` for `Pass` and `Skip` statuses — only `Fail` gets an explanation.
+pub fn explain_check(name: &str, status: &CheckStatus) -> Option<CheckExplanation> {
+    if !matches!(status, CheckStatus::Fail) {
+        return None;
+    }
+
+    let explanation = match name {
+        "signature" => CheckExplanation {
+            why: "The Ed25519 signature does not match the provided public key.",
+            fix: "Verify you are using the correct public key (--public-key or --public-key-file).",
+        },
+        "model_match" => CheckExplanation {
+            why: "The receipt's model_id does not match the expected model.",
+            fix: "Check that --expected-model matches the model ID in the receipt.",
+        },
+        "measurement_type" => CheckExplanation {
+            why: "The receipt's measurement type does not match the expected platform.",
+            fix: "Check --measurement-type (e.g. nitro-pcr, tdx-mrtd-rtmr, or any).",
+        },
+        "timestamp_fresh" => CheckExplanation {
+            why: "The receipt timestamp is either too old or in the future.",
+            fix: "Increase --max-age or set to 0 to skip. Check system clock sync.",
+        },
+        "measurements_present" => CheckExplanation {
+            why: "The enclave measurement fields are missing or the wrong length (expected 48 bytes / SHA-384).",
+            fix: "This usually indicates a mock receipt or a corrupted receipt file.",
+        },
+        "attestation_source" => CheckExplanation {
+            why: "The receipt's attestation_source does not match the expected value.",
+            fix: "Check --expected-attestation-source (e.g. cs-tdx, tdx, nitro).",
+        },
+        "image_digest" => CheckExplanation {
+            why: "The container image digest in the receipt does not match the expected value.",
+            fix: "Check --expected-image-digest matches the deployed container digest.",
+        },
+        _ => return None,
+    };
+
+    Some(explanation)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pass_returns_none() {
+        assert!(explain_check("signature", &CheckStatus::Pass).is_none());
+    }
+
+    #[test]
+    fn skip_returns_none() {
+        assert!(explain_check("model_match", &CheckStatus::Skip).is_none());
+    }
+
+    #[test]
+    fn fail_returns_explanation() {
+        let exp = explain_check("signature", &CheckStatus::Fail).unwrap();
+        assert!(!exp.why.is_empty());
+        assert!(!exp.fix.is_empty());
+    }
+
+    #[test]
+    fn all_seven_checks_covered() {
+        let names = [
+            "signature",
+            "model_match",
+            "measurement_type",
+            "timestamp_fresh",
+            "measurements_present",
+            "attestation_source",
+            "image_digest",
+        ];
+        for name in &names {
+            let exp = explain_check(name, &CheckStatus::Fail);
+            assert!(exp.is_some(), "Missing explanation for check: {}", name);
+        }
+    }
+
+    #[test]
+    fn unknown_check_returns_none() {
+        assert!(explain_check("nonexistent", &CheckStatus::Fail).is_none());
+    }
+}

--- a/common/src/ui/mascot.rs
+++ b/common/src/ui/mascot.rs
@@ -1,0 +1,50 @@
+/// Ghost states for the mascot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GhostState {
+    Idle,
+    Success,
+    Fail,
+}
+
+/// Return the 3-line ASCII ghost for the given state.
+pub fn ghost_lines(state: GhostState) -> [&'static str; 3] {
+    match state {
+        GhostState::Idle => ["  .--. ", " / oo \\", " \\ -- /"],
+        GhostState::Success => ["  .--. ", " / ^^ \\", " \\ -- /"],
+        GhostState::Fail => ["  .--. ", " / xx \\", " \\ -- /"],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_states_produce_3_lines() {
+        for state in [GhostState::Idle, GhostState::Success, GhostState::Fail] {
+            let lines = ghost_lines(state);
+            assert_eq!(lines.len(), 3);
+            for line in &lines {
+                assert!(!line.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn idle_has_oo_eyes() {
+        let lines = ghost_lines(GhostState::Idle);
+        assert!(lines[1].contains("oo"));
+    }
+
+    #[test]
+    fn success_has_caret_eyes() {
+        let lines = ghost_lines(GhostState::Success);
+        assert!(lines[1].contains("^^"));
+    }
+
+    #[test]
+    fn fail_has_xx_eyes() {
+        let lines = ghost_lines(GhostState::Fail);
+        assert!(lines[1].contains("xx"));
+    }
+}

--- a/common/src/ui/mod.rs
+++ b/common/src/ui/mod.rs
@@ -1,0 +1,9 @@
+pub mod config;
+pub mod explain;
+pub mod mascot;
+pub mod render;
+
+pub use config::UiConfig;
+pub use explain::{explain_check, CheckExplanation};
+pub use mascot::{ghost_lines, GhostState};
+pub use render::Ui;

--- a/common/src/ui/render.rs
+++ b/common/src/ui/render.rs
@@ -1,0 +1,479 @@
+use super::config::UiConfig;
+use super::explain::explain_check;
+use super::mascot::{ghost_lines, GhostState};
+use crate::receipt_verify::CheckStatus;
+use std::io::Write;
+
+// ANSI escape codes
+const BOLD: &str = "\x1b[1m";
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+/// Structured CLI output renderer.
+///
+/// Holds a `UiConfig` and a writer (stdout by default, `Vec<u8>` in tests).
+pub struct Ui {
+    config: UiConfig,
+    writer: Box<dyn Write>,
+}
+
+impl Ui {
+    /// Create a new Ui writing to stdout.
+    pub fn stdout(config: UiConfig) -> Self {
+        Self {
+            config,
+            writer: Box::new(std::io::stdout()),
+        }
+    }
+
+    /// Create a new Ui writing to an arbitrary writer (for testing).
+    pub fn new(config: UiConfig, writer: Box<dyn Write>) -> Self {
+        Self { config, writer }
+    }
+
+    /// Access the config.
+    pub fn config(&self) -> &UiConfig {
+        &self.config
+    }
+
+    // -- ANSI helpers --
+
+    fn bold(&self, text: &str) -> String {
+        if self.config.color {
+            format!("{BOLD}{text}{RESET}")
+        } else {
+            text.to_string()
+        }
+    }
+
+    fn green(&self, text: &str) -> String {
+        if self.config.color {
+            format!("{GREEN}{text}{RESET}")
+        } else {
+            text.to_string()
+        }
+    }
+
+    fn red(&self, text: &str) -> String {
+        if self.config.color {
+            format!("{RED}{text}{RESET}")
+        } else {
+            text.to_string()
+        }
+    }
+
+    fn yellow(&self, text: &str) -> String {
+        if self.config.color {
+            format!("{YELLOW}{text}{RESET}")
+        } else {
+            text.to_string()
+        }
+    }
+
+    fn dim(&self, text: &str) -> String {
+        if self.config.color {
+            format!("{DIM}{text}{RESET}")
+        } else {
+            text.to_string()
+        }
+    }
+
+    // -- Output methods --
+
+    /// Print a blank line.
+    pub fn blank(&mut self) {
+        let _ = writeln!(self.writer);
+    }
+
+    /// Print a major header with `====` bars.
+    pub fn header(&mut self, title: &str) {
+        let bar = "=".repeat(62);
+        let _ = writeln!(self.writer, "  {}", self.dim(&bar));
+        let _ = writeln!(self.writer, "  {}", self.bold(title));
+        let _ = writeln!(self.writer, "  {}", self.dim(&bar));
+    }
+
+    /// Print a section header with `----` bars.
+    pub fn section(&mut self, title: &str) {
+        let thin = "-".repeat(62);
+        let _ = writeln!(self.writer, "  {}", self.dim(&thin));
+        let _ = writeln!(self.writer, "  {}:", self.bold(title));
+        let _ = writeln!(self.writer, "  {}", self.dim(&thin));
+    }
+
+    /// Print a thin divider line.
+    pub fn divider(&mut self) {
+        let thin = "-".repeat(62);
+        let _ = writeln!(self.writer, "  {}", self.dim(&thin));
+    }
+
+    /// Print a key-value pair, indented.
+    pub fn kv(&mut self, key: &str, value: &str) {
+        let _ = writeln!(self.writer, "  {:<13}{}", format!("{}:", key), value);
+    }
+
+    /// Print a check result line with [PASS]/[FAIL]/[SKIP] badge.
+    pub fn check(&mut self, label: &str, status: &CheckStatus) {
+        let badge = match status {
+            CheckStatus::Pass => self.green("[PASS]"),
+            CheckStatus::Fail => self.red("[FAIL]"),
+            CheckStatus::Skip => self.dim("[SKIP]"),
+        };
+        let _ = writeln!(self.writer, "  {:<28}{}", label, badge);
+    }
+
+    /// Print a check with an inline explanation if the check failed.
+    ///
+    /// `check_name` is the canonical name used by `explain_check` (e.g. "signature").
+    /// `label` is the display name shown on the check line.
+    pub fn check_explained(&mut self, label: &str, check_name: &str, status: &CheckStatus) {
+        self.check(label, status);
+        if let Some(exp) = explain_check(check_name, status) {
+            let why = self.dim(&format!("Why: {}", exp.why));
+            let fix = self.dim(&format!("Fix: {}", exp.fix));
+            let _ = writeln!(self.writer, "    {}", why);
+            let _ = writeln!(self.writer, "    {}", fix);
+        }
+    }
+
+    /// Print a success message (bold green).
+    pub fn success(&mut self, msg: &str) {
+        let _ = writeln!(self.writer, "  {}", self.green(&self.bold(msg)));
+    }
+
+    /// Print a failure message (bold red).
+    pub fn failure(&mut self, msg: &str) {
+        let _ = writeln!(self.writer, "  {}", self.red(&self.bold(msg)));
+    }
+
+    /// Print a warning message (yellow).
+    pub fn warn(&mut self, msg: &str) {
+        let _ = writeln!(self.writer, "  {}", self.yellow(msg));
+    }
+
+    /// Print a bullet point, indented.
+    pub fn bullet(&mut self, msg: &str) {
+        let _ = writeln!(self.writer, "    - {}", msg);
+    }
+
+    /// Print an indented info line.
+    pub fn info(&mut self, msg: &str) {
+        let _ = writeln!(self.writer, "  {}", msg);
+    }
+
+    /// Print a stage summary line (for pipeline verification).
+    pub fn stage_line(&mut self, text: &str) {
+        let _ = writeln!(self.writer, "  {}", text);
+    }
+
+    /// Print a tagged status line like "Chain[0]    PASS  root (no predecessor)".
+    pub fn chain_status(&mut self, label: &str, pass: bool, detail: &str) {
+        let tag = if pass {
+            self.green("PASS")
+        } else {
+            self.red("FAIL")
+        };
+        let _ = writeln!(self.writer, "  {:<14}{}  {}", label, tag, detail);
+    }
+
+    /// Print the final verification verdict.
+    pub fn verdict(&mut self, verified: bool, detail: &str) {
+        self.blank();
+        if verified {
+            let msg = format!("  --> PIPELINE VERIFIED ({})", detail);
+            let _ = writeln!(self.writer, "{}", self.green(&msg));
+        } else {
+            let _ = writeln!(self.writer, "{}", self.red("  --> PIPELINE INVALID"));
+        }
+    }
+
+    /// Print the ghost mascot if mascot is enabled in config.
+    pub fn ghost(&mut self, state: GhostState) {
+        if !self.config.mascot {
+            return;
+        }
+        let color_fn = match state {
+            GhostState::Idle => None,
+            GhostState::Success => Some(GREEN),
+            GhostState::Fail => Some(RED),
+        };
+        let lines = ghost_lines(state);
+        for line in &lines {
+            if let Some(color) = color_fn {
+                let _ = writeln!(self.writer, "  {}{}{}", color, line, RESET);
+            } else {
+                let _ = writeln!(self.writer, "  {}", line);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plain_config() -> UiConfig {
+        UiConfig {
+            color: false,
+            mascot: false,
+        }
+    }
+
+    fn color_config() -> UiConfig {
+        UiConfig {
+            color: true,
+            mascot: true,
+        }
+    }
+
+    struct CaptureBuf {
+        inner: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    }
+
+    impl CaptureBuf {
+        fn new() -> (Self, std::sync::Arc<std::sync::Mutex<Vec<u8>>>) {
+            let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            (Self { inner: buf.clone() }, buf)
+        }
+    }
+
+    impl Write for CaptureBuf {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            self.inner.lock().unwrap().write(data)
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn run_ui(config: UiConfig, f: impl FnOnce(&mut Ui)) -> String {
+        let (cap, buf) = CaptureBuf::new();
+        let mut ui = Ui::new(config, Box::new(cap));
+        f(&mut ui);
+        drop(ui);
+        let locked = buf.lock().unwrap();
+        String::from_utf8(locked.clone()).unwrap()
+    }
+
+    #[test]
+    fn header_produces_bar_lines() {
+        let out = run_ui(plain_config(), |ui| ui.header("Test Title"));
+        assert!(out.contains("===="));
+        assert!(out.contains("Test Title"));
+        // Output should have 3 lines: bar, title, bar
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains("===="));
+        assert!(lines[1].contains("Test Title"));
+        assert!(lines[2].contains("===="));
+    }
+
+    #[test]
+    fn check_pass_produces_pass_badge() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.check("Signature (Ed25519)", &CheckStatus::Pass);
+        });
+        assert!(out.contains("[PASS]"));
+        assert!(out.contains("Signature (Ed25519)"));
+    }
+
+    #[test]
+    fn check_fail_produces_fail_badge() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.check("Signature (Ed25519)", &CheckStatus::Fail);
+        });
+        assert!(out.contains("[FAIL]"));
+    }
+
+    #[test]
+    fn check_skip_produces_skip_badge() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.check("Model ID match", &CheckStatus::Skip);
+        });
+        assert!(out.contains("[SKIP]"));
+    }
+
+    #[test]
+    fn no_ansi_in_plain_mode() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.header("Title");
+            ui.check("Sig", &CheckStatus::Pass);
+            ui.success("OK");
+            ui.failure("BAD");
+            ui.warn("WARN");
+        });
+        assert!(!out.contains("\x1b["));
+    }
+
+    #[test]
+    fn ansi_present_in_color_mode() {
+        let out = run_ui(color_config(), |ui| {
+            ui.check("Sig", &CheckStatus::Pass);
+        });
+        assert!(out.contains("\x1b[32m")); // GREEN
+    }
+
+    #[test]
+    fn kv_formats_correctly() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.kv("Receipt", "abc-123");
+        });
+        assert!(out.contains("Receipt:"));
+        assert!(out.contains("abc-123"));
+    }
+
+    #[test]
+    fn bullet_formats_correctly() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.bullet("Something went wrong");
+        });
+        assert!(out.contains("- Something went wrong"));
+    }
+
+    #[test]
+    fn success_and_failure() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.success("VERIFIED");
+            ui.failure("INVALID");
+        });
+        assert!(out.contains("VERIFIED"));
+        assert!(out.contains("INVALID"));
+    }
+
+    #[test]
+    fn check_explained_shows_why_fix_on_fail() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.check_explained("Signature (Ed25519)", "signature", &CheckStatus::Fail);
+        });
+        assert!(out.contains("[FAIL]"));
+        assert!(out.contains("Why:"));
+        assert!(out.contains("Fix:"));
+    }
+
+    #[test]
+    fn check_explained_no_extra_on_pass() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.check_explained("Signature (Ed25519)", "signature", &CheckStatus::Pass);
+        });
+        assert!(out.contains("[PASS]"));
+        assert!(!out.contains("Why:"));
+        assert!(!out.contains("Fix:"));
+    }
+
+    #[test]
+    fn ghost_hidden_when_mascot_disabled() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.ghost(GhostState::Idle);
+        });
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn ghost_shown_when_mascot_enabled() {
+        let out = run_ui(color_config(), |ui| {
+            ui.ghost(GhostState::Idle);
+        });
+        assert!(out.contains(".--.")); // ghost top
+        assert!(out.contains("oo")); // idle eyes
+    }
+
+    #[test]
+    fn ghost_success_has_caret_eyes() {
+        let out = run_ui(color_config(), |ui| {
+            ui.ghost(GhostState::Success);
+        });
+        assert!(out.contains("^^"));
+    }
+
+    #[test]
+    fn ghost_fail_has_xx_eyes() {
+        let out = run_ui(color_config(), |ui| {
+            ui.ghost(GhostState::Fail);
+        });
+        assert!(out.contains("xx"));
+    }
+
+    #[test]
+    fn section_produces_dashes() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.section("Checks");
+        });
+        assert!(out.contains("----"));
+        assert!(out.contains("Checks:"));
+    }
+
+    #[test]
+    fn divider_produces_dashes() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.divider();
+        });
+        assert!(out.contains("----"));
+    }
+
+    #[test]
+    fn chain_status_shows_pass_fail() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.chain_status("Chain[0]", true, "root");
+            ui.chain_status("Chain[1]", false, "mismatch");
+        });
+        assert!(out.contains("PASS"));
+        assert!(out.contains("FAIL"));
+        assert!(out.contains("root"));
+        assert!(out.contains("mismatch"));
+    }
+
+    #[test]
+    fn verdict_verified() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.verdict(true, "2 stages, intact");
+        });
+        assert!(out.contains("PIPELINE VERIFIED"));
+        assert!(out.contains("2 stages, intact"));
+    }
+
+    #[test]
+    fn verdict_invalid() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.verdict(false, "");
+        });
+        assert!(out.contains("PIPELINE INVALID"));
+    }
+
+    #[test]
+    fn full_verify_report_structure_plain() {
+        let out = run_ui(plain_config(), |ui| {
+            ui.blank();
+            ui.header("EphemeralML Receipt Verification");
+            ui.blank();
+            ui.kv("Receipt", "abc-123");
+            ui.kv("Model", "minilm v1.0");
+            ui.kv("Platform", "nitro-pcr");
+            ui.blank();
+            ui.section("Checks");
+            ui.check_explained("Signature (Ed25519)", "signature", &CheckStatus::Pass);
+            ui.check_explained("Model ID match", "model_match", &CheckStatus::Fail);
+            ui.divider();
+            ui.blank();
+            ui.failure("INVALID");
+            ui.blank();
+        });
+
+        // Structural assertions
+        assert!(out.contains("===="));
+        assert!(out.contains("EphemeralML Receipt Verification"));
+        assert!(out.contains("Receipt:"));
+        assert!(out.contains("abc-123"));
+        assert!(out.contains("----"));
+        assert!(out.contains("Checks:"));
+        assert!(out.contains("[PASS]"));
+        assert!(out.contains("[FAIL]"));
+        assert!(out.contains("Why:"));
+        assert!(out.contains("Fix:"));
+        assert!(out.contains("INVALID"));
+        // No ANSI in plain mode
+        assert!(!out.contains("\x1b["));
+    }
+}

--- a/docs/cli-ux.md
+++ b/docs/cli-ux.md
@@ -1,0 +1,147 @@
+# EphemeralML CLI UX Contract
+
+This document defines the output conventions for all EphemeralML CLI tools and shell scripts.
+
+## Output Modes
+
+| Mode | When | Colors | Mascot | Structure |
+|------|------|--------|--------|-----------|
+| **Rich** | TTY detected, no overrides | Yes | Yes | Headers, badges, kv pairs |
+| **Plain** | `--plain`, non-TTY, CI, `NO_COLOR` | No | No | Same structure, no ANSI |
+| **JSON** | `--format json` | No | No | Machine-readable JSON |
+
+## Color Policy
+
+Colors are enabled when **all** of the following are true:
+- stdout is a TTY (`std::io::IsTerminal`)
+- `NO_COLOR` environment variable is **not** set
+- `CI` environment variable is **not** set
+- `--plain` flag was **not** passed
+- `--no-color` flag was **not** passed
+- `--format json` was **not** passed
+
+Override with `EPHEMERALML_UI=rich` to force colors on, or `EPHEMERALML_UI=plain` to force off.
+
+## Ghost Mascot
+
+A 3-line ASCII ghost appears at the start (idle) and end (success/fail) of commands:
+
+```
+  .--.
+ / oo \     (idle)
+ \ -- /
+
+  .--.
+ / ^^ \     (success - green)
+ \ -- /
+
+  .--.
+ / xx \     (fail - red)
+ \ -- /
+```
+
+Suppressed by: `--no-mascot`, `--plain`, `--format json`, non-TTY, `NO_COLOR`, `CI`, `EPHEMERALML_NO_MASCOT` (shell scripts).
+
+## CLI Flags (all binaries)
+
+| Flag | Effect |
+|------|--------|
+| `--plain` | Disable all colors and mascot |
+| `--no-color` | Disable color output only |
+| `--no-mascot` | Disable ghost mascot only |
+| `--format json` | JSON output (ephemeralml-verify only) |
+
+## Exit Codes
+
+| Binary | Code | Meaning |
+|--------|------|---------|
+| `ephemeralml infer` | 0 | Inference succeeded |
+| `ephemeralml infer` | 1 | Inference failed |
+| `ephemeralml verify-pipeline` | 0 | Pipeline verified |
+| `ephemeralml verify-pipeline` | 1 | Pipeline invalid |
+| `ephemeralml-verify` | 0 | Receipt verified |
+| `ephemeralml-verify` | 1 | Receipt invalid |
+| `ephemeralml-verify` | 2 | Error (bad input) |
+| `ephemeralml-orchestrator` | 0 | Pipeline completed |
+| `ephemeralml-orchestrator` | 1 | Pipeline or chain failed |
+
+## Explainable Trust Output
+
+When a verification check fails (`[FAIL]`), an inline explanation appears:
+
+```
+  Signature (Ed25519)       [FAIL]
+    Why: The Ed25519 signature does not match the provided public key.
+    Fix: Verify you are using the correct public key (--public-key or --public-key-file).
+```
+
+All 7 checks have explanations: `signature`, `model_match`, `measurement_type`, `timestamp_fresh`, `measurements_present`, `attestation_source`, `image_digest`.
+
+`[PASS]` and `[SKIP]` checks show no explanation.
+
+## Shell Script Conventions
+
+### Shared Library
+
+All GCP scripts source `scripts/lib/ui.sh`, which provides:
+
+- `ui_header`, `ui_section`, `ui_kv`, `ui_ok`, `ui_fail`, `ui_warn`, `ui_info`, `ui_bullet`, `ui_blank`
+- `run_step STEP_NUM TOTAL LABEL COMMAND...` — collapsed build/deploy output
+- `ui_ghost_idle`, `ui_ghost_ok`, `ui_ghost_fail` — shell mascot
+
+### `run_step` Behavior
+
+```bash
+run_step 3 6 "Building container image" docker build ...
+```
+
+1. Prints `[3/6] Building container image...`
+2. Captures stdout+stderr to a tempfile
+3. On success: `[OK] Building container image (12s)`
+4. On failure: `[FAIL] Building container image (exit 1, 5s)` + last 20 lines + log path
+5. `VERBOSE=true`: streams output live
+
+### Environment Variables
+
+| Variable | Effect |
+|----------|--------|
+| `NO_COLOR` | Disable colors in all tools |
+| `CI` | Disable colors (auto-detected in CI) |
+| `VERBOSE` | Stream full build output instead of collapsing |
+| `EPHEMERALML_UI` | `rich` or `plain` — override color detection |
+| `EPHEMERALML_NO_MASCOT` | Suppress ghost mascot in shell scripts |
+
+## JSON Stability Contract
+
+The `--format json` output of `ephemeralml-verify` produces a `VerifyResult` struct. The following fields are stable:
+
+- `verified` (bool)
+- `receipt_id` (string)
+- `model_id` (string)
+- `model_version` (string)
+- `measurement_type` (string)
+- `sequence_number` (u64)
+- `execution_timestamp` (u64)
+- `checks.signature` / `checks.model_match` / etc. ("pass" | "fail" | "skip")
+- `errors` (array of strings)
+- `warnings` (array of strings)
+
+New fields may be added. Existing fields will not be removed or renamed without a major version bump.
+
+## Troubleshooting
+
+### No colors in terminal
+
+Check: `echo $TERM`, `echo $NO_COLOR`, `echo $CI`. Force with `EPHEMERALML_UI=rich`.
+
+### Ghost not showing
+
+The ghost only shows when colors are enabled. Check `--plain`, `--no-mascot`, `EPHEMERALML_NO_MASCOT`.
+
+### Build output flooding the screen
+
+Use default mode (output is collapsed). If already collapsed, the failure happened — check the log path printed by `run_step`.
+
+### `deploy.sh` shows full Docker output
+
+This is expected with `VERBOSE=true`. Unset it to collapse output.

--- a/scripts/lib/ui.sh
+++ b/scripts/lib/ui.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# EphemeralML shared shell UI helpers.
+#
+# Source this file in any script:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "${SCRIPT_DIR}/../lib/ui.sh"   # from scripts/gcp/
+#   source "${SCRIPT_DIR}/lib/ui.sh"      # from scripts/
+#
+# Respects: NO_COLOR, CI, VERBOSE, EPHEMERALML_NO_MASCOT
+# TTY detection: colors enabled only when stdout is a terminal.
+
+# ---------------------------------------------------------------------------
+# Color / TTY detection
+# ---------------------------------------------------------------------------
+_UI_COLOR=false
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ -z "${CI:-}" ]; then
+    _UI_COLOR=true
+fi
+
+_UI_BOLD=""
+_UI_GREEN=""
+_UI_RED=""
+_UI_YELLOW=""
+_UI_DIM=""
+_UI_RESET=""
+
+if $_UI_COLOR; then
+    _UI_BOLD="\033[1m"
+    _UI_GREEN="\033[32m"
+    _UI_RED="\033[31m"
+    _UI_YELLOW="\033[33m"
+    _UI_DIM="\033[2m"
+    _UI_RESET="\033[0m"
+fi
+
+# ---------------------------------------------------------------------------
+# Basic output helpers
+# ---------------------------------------------------------------------------
+
+ui_header() {
+    local title="$1"
+    local bar
+    bar="$(printf '=%.0s' {1..62})"
+    echo -e "  ${_UI_DIM}${bar}${_UI_RESET}"
+    echo -e "  ${_UI_BOLD}${title}${_UI_RESET}"
+    echo -e "  ${_UI_DIM}${bar}${_UI_RESET}"
+}
+
+ui_section() {
+    local title="$1"
+    local thin
+    thin="$(printf -- '-%.0s' {1..62})"
+    echo -e "  ${_UI_DIM}${thin}${_UI_RESET}"
+    echo -e "  ${_UI_BOLD}${title}:${_UI_RESET}"
+    echo -e "  ${_UI_DIM}${thin}${_UI_RESET}"
+}
+
+ui_kv() {
+    local key="$1"
+    local value="$2"
+    printf "  %-13s %s\n" "${key}:" "${value}"
+}
+
+ui_ok() {
+    local msg="$1"
+    echo -e "  ${_UI_GREEN}${_UI_BOLD}${msg}${_UI_RESET}"
+}
+
+ui_fail() {
+    local msg="$1"
+    echo -e "  ${_UI_RED}${_UI_BOLD}${msg}${_UI_RESET}"
+}
+
+ui_warn() {
+    local msg="$1"
+    echo -e "  ${_UI_YELLOW}${msg}${_UI_RESET}"
+}
+
+ui_info() {
+    local msg="$1"
+    echo "  ${msg}"
+}
+
+ui_bullet() {
+    local msg="$1"
+    echo "    - ${msg}"
+}
+
+ui_blank() {
+    echo
+}
+
+# ---------------------------------------------------------------------------
+# run_step — run a command with collapsed output
+# ---------------------------------------------------------------------------
+# Usage: run_step STEP_NUM TOTAL LABEL COMMAND...
+#
+# 1. Prints "[N/M] Label..."
+# 2. Runs command, captures stdout+stderr to tempfile
+# 3. On success: prints "[OK] Label (Xs)"
+# 4. On failure: prints "[FAIL] Label (exit N)" + last 20 lines + log path
+# 5. With VERBOSE=true: streams output live instead of capturing
+run_step() {
+    local step_num="$1"; shift
+    local step_total="$1"; shift
+    local label="$1"; shift
+    # Remaining args are the command
+
+    local prefix="[${step_num}/${step_total}]"
+
+    if [ "${VERBOSE:-false}" = "true" ]; then
+        echo -e "${_UI_DIM}${prefix}${_UI_RESET} ${label}..."
+        # Capture exit code without triggering set -e
+        local exit_code=0
+        "$@" || exit_code=$?
+        if [ $exit_code -eq 0 ]; then
+            echo -e "  ${_UI_GREEN}[OK]${_UI_RESET} ${label}"
+        else
+            echo -e "  ${_UI_RED}[FAIL]${_UI_RESET} ${label} (exit ${exit_code})"
+            return $exit_code
+        fi
+        return 0
+    fi
+
+    echo -e -n "${_UI_DIM}${prefix}${_UI_RESET} ${label}..."
+
+    local logfile
+    logfile="$(mktemp "/tmp/ephemeralml-step-${step_num}-XXXXXX.log")"
+
+    local start_time
+    start_time=$(date +%s)
+
+    # Capture exit code without triggering set -e
+    local exit_code=0
+    "$@" >"${logfile}" 2>&1 || exit_code=$?
+
+    local end_time
+    end_time=$(date +%s)
+    local elapsed=$(( end_time - start_time ))
+
+    if [ $exit_code -eq 0 ]; then
+        echo -e "\r  ${_UI_GREEN}[OK]${_UI_RESET} ${label} (${elapsed}s)          "
+        rm -f "${logfile}"
+    else
+        echo -e "\r  ${_UI_RED}[FAIL]${_UI_RESET} ${label} (exit ${exit_code}, ${elapsed}s)          "
+        echo
+        echo "  Last 20 lines:"
+        tail -20 "${logfile}" | sed 's/^/    /'
+        echo
+        echo "  Full log: ${logfile}"
+        return $exit_code
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Ghost mascot (shell version)
+# ---------------------------------------------------------------------------
+_UI_MASCOT=true
+if [ -n "${EPHEMERALML_NO_MASCOT:-}" ] || ! $_UI_COLOR; then
+    _UI_MASCOT=false
+fi
+
+ui_ghost_idle() {
+    if $_UI_MASCOT; then
+        echo "    .--."
+        echo "   / oo \\"
+        echo "   \\ -- /"
+    fi
+}
+
+ui_ghost_ok() {
+    if $_UI_MASCOT; then
+        echo -e "    ${_UI_GREEN}.--."
+        echo -e "   / ^^ \\"
+        echo -e "   \\ -- /${_UI_RESET}"
+    fi
+}
+
+ui_ghost_fail() {
+    if $_UI_MASCOT; then
+        echo -e "    ${_UI_RED}.--."
+        echo -e "   / xx \\"
+        echo -e "   \\ -- /${_UI_RESET}"
+    fi
+}


### PR DESCRIPTION
## Summary

- Replace raw `println!` across all 3 CLI binaries (`ephemeralml`, `ephemeralml-verify`, `orchestrator`) with a structured `Ui` renderer in `common/src/ui/`
- Add `UiConfig` with correct precedence: CLI flags (`--plain`, `--no-color`, `--no-mascot`) > env vars (`EPHEMERALML_UI`, `NO_COLOR`, `CI`) > TTY auto-detect
- Add explainable trust output: `[FAIL]` checks show inline "Why:" and "Fix:" explanations for all 7 verification checks
- Add 3-line ASCII ghost mascot (idle/success/fail states), suppressed in plain/CI/non-TTY modes
- Add shared shell UI library (`scripts/lib/ui.sh`) with `set -e`-safe `run_step` for collapsed build/deploy logs
- Add `shell-lint` CI job (bash syntax + shellcheck)
- Add `docs/cli-ux.md` UX contract documenting output modes, color policy, exit codes, JSON stability

## Test plan

- [x] 147 workspace tests pass (`cargo test --workspace`)
- [x] 42 new UI tests: 12 config, 5 explain, 4 mascot, 21 render
- [x] Zero clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] Shell syntax check passes (`bash -n scripts/lib/ui.sh scripts/gcp/*.sh`)
- [x] `run_step` verified safe under `set -e`
- [x] `EnvState` struct eliminates flaky parallel test races from `std::env::set_var`
- [ ] Verify `shell-lint` CI job passes on GitHub Actions (shellcheck for `ui.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)