### PR TITLE
feat: verifier API hardening — auth, rate limiting, policy parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.2.5] - 2026-02-18
+
+### Added
+- **API key authentication**: Verify endpoints require `Authorization: Bearer <key>` or `X-API-Key: <key>`. Fail-closed: startup fails without `--api-key` or `--insecure-no-auth`.
+- **Per-IP rate limiting**: 60 req/min/IP default via `--rate-limit`. Returns 429 when exceeded. Health endpoint exempt.
+- **CORS tightening**: With auth enabled, startup fails if no `--cors-origin` unless `--allow-permissive-cors` is set.
+- **New policy fields in verifier API**: `expected_attestation_source` and `expected_image_digest` on both JSON and multipart endpoints.
+- **Verifier API documentation**: `docs/verifier-api.md` with auth, rate limits, policy fields, curl examples.
+- **12 new tests**: Auth success/failure (Bearer + X-API-Key), rate limit enforcement, policy field acceptance/skip, backward compatibility, health/landing auth exemption.
+
+### Changed
+- **Version bump**: All crates from 0.2.4 to 0.2.5
+
+### Security
+- No silent insecure defaults. Auth, rate limiting, and CORS require explicit opt-out with loud warnings.
+- New env vars: `EPHEMERALML_VERIFIER_API_KEY`, `EPHEMERALML_VERIFIER_NO_AUTH`, `EPHEMERALML_VERIFIER_RATE_LIMIT`.
+- New CLI flags: `--api-key`, `--insecure-no-auth`, `--rate-limit`, `--allow-permissive-cors`.
+
 ## [0.2.4] - 2026-02-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-ml-client"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-ml-common"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-ml-compliance"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "ciborium",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-ml-enclave"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-ml-host"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeralml-verifier-api"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ephemeral-ml-client"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ephemeral-ml-common"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/compliance/Cargo.toml
+++ b/compliance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ephemeral-ml-compliance"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "Compliance evidence bundle generation and verification for EphemeralML"

--- a/docs/verifier-api.md
+++ b/docs/verifier-api.md
@@ -1,0 +1,195 @@
+# Verifier API Reference
+
+## Overview
+
+The EphemeralML Verifier API is a hosted HTTP service for verifying attested execution receipts. It wraps the same `verify_receipt()` logic as the CLI verifier in a REST API.
+
+## Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/` | No | Landing page (HTML form) |
+| `GET` | `/health` | No | Liveness probe |
+| `POST` | `/api/v1/verify` | Yes | Verify receipt (JSON body) |
+| `POST` | `/api/v1/verify/upload` | Yes | Verify receipt (multipart upload) |
+
+## Authentication
+
+The verify endpoints require an API key when auth is enabled (default for production).
+
+**Supported headers** (either one):
+- `Authorization: Bearer <API_KEY>`
+- `X-API-Key: <API_KEY>`
+
+**Configuration:**
+
+| Flag / Env Var | Default | Description |
+|----------------|---------|-------------|
+| `--api-key` / `EPHEMERALML_VERIFIER_API_KEY` | (none) | API key for verify endpoints |
+| `--insecure-no-auth` / `EPHEMERALML_VERIFIER_NO_AUTH=true` | `false` | Disable auth (dev only) |
+
+**Startup behavior:**
+- If `--api-key` is set: auth enabled, verify endpoints require the key
+- If `--insecure-no-auth`: auth disabled, loud warning logged
+- If neither: **startup fails** with instructions (fail-closed)
+
+Health (`/health`) and landing page (`/`) never require auth.
+
+## Rate Limiting
+
+Per-IP sliding window rate limiter. Returns `429 Too Many Requests` when exceeded.
+
+| Flag / Env Var | Default | Description |
+|----------------|---------|-------------|
+| `--rate-limit` / `EPHEMERALML_VERIFIER_RATE_LIMIT` | `60` | Max requests per minute per IP |
+
+Set to `0` to disable (with warning). Health endpoint is exempt.
+
+## CORS
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--cors-origin <URL>` | (none) | Allowed origin (repeatable) |
+| `--allow-permissive-cors` | `false` | Override CORS fail-closed with auth |
+
+**Behavior:**
+- With `--cors-origin`: explicit allowlist
+- Without `--cors-origin` + no auth: permissive (with warning)
+- Without `--cors-origin` + auth: **startup fails** unless `--allow-permissive-cors`
+
+## JSON Endpoint
+
+### `POST /api/v1/verify`
+
+**Request body:**
+
+```json
+{
+  "receipt": { ... },
+  "public_key": "64-char-hex-ed25519-public-key",
+  "expected_model": "minilm-l6-v2",
+  "max_age_secs": 3600,
+  "measurement_type": "any",
+  "expected_attestation_source": "cs-tdx",
+  "expected_image_digest": "sha256:068c3cdf..."
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `receipt` | object/string | Yes | — | JSON receipt or base64 CBOR |
+| `public_key` | string | Yes | — | 64-char hex Ed25519 public key |
+| `expected_model` | string | No | skip | Expected model ID |
+| `max_age_secs` | u64 | No | `0` (skip) | Max receipt age |
+| `measurement_type` | string | No | `"any"` | Expected measurement type |
+| `expected_attestation_source` | string | No | skip | e.g. `"cs-tdx"`, `"aws-nitro"` |
+| `expected_image_digest` | string | No | skip | e.g. `"sha256:abc123"` |
+
+**Response (200):**
+
+```json
+{
+  "verified": true,
+  "receipt_id": "98aee3e7-...",
+  "model_id": "minilm-l6-v2",
+  "model_version": "v1.0",
+  "checks": {
+    "signature": "pass",
+    "model_match": "pass",
+    "measurement_type": "skip",
+    "timestamp_fresh": "skip",
+    "measurements_present": "pass",
+    "attestation_source": "skip",
+    "image_digest": "skip"
+  },
+  "errors": [],
+  "warnings": [],
+  "api_version": "v1",
+  "verified_at": 1708000100
+}
+```
+
+## Multipart Endpoint
+
+### `POST /api/v1/verify/upload`
+
+**Form fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `receipt_file` | file | Yes | Receipt (JSON or CBOR) |
+| `public_key` | text | Yes* | 64-char hex Ed25519 key |
+| `public_key_file` | file | Yes* | 32-byte binary Ed25519 key |
+| `expected_model` | text | No | Expected model ID |
+| `measurement_type` | text | No | Expected measurement type |
+| `max_age_secs` | text | No | Max receipt age (integer) |
+| `expected_attestation_source` | text | No | Expected attestation source |
+| `expected_image_digest` | text | No | Expected image digest |
+
+\* Provide either `public_key` or `public_key_file`, not both.
+
+## curl Examples
+
+### JSON endpoint with Bearer auth
+
+```bash
+curl -X POST https://verifier.example.com/api/v1/verify \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "receipt": '"$(cat receipt.json)"',
+    "public_key": "aabbccdd...",
+    "expected_attestation_source": "cs-tdx"
+  }'
+```
+
+### Multipart upload with X-API-Key
+
+```bash
+curl -X POST https://verifier.example.com/api/v1/verify/upload \
+  -H "X-API-Key: YOUR_API_KEY" \
+  -F "receipt_file=@receipt.json" \
+  -F "public_key=aabbccdd..." \
+  -F "expected_model=minilm-l6-v2" \
+  -F "expected_image_digest=sha256:068c3cdf..."
+```
+
+### Local dev (no auth)
+
+```bash
+ephemeralml-verifier --insecure-no-auth --rate-limit 0
+
+curl -X POST http://localhost:8080/api/v1/verify \
+  -H "Content-Type: application/json" \
+  -d '{"receipt": ..., "public_key": "..."}'
+```
+
+## Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Verification complete (check `verified` field) |
+| `400` | Bad request (invalid key, malformed receipt) |
+| `401` | Unauthorized (missing or invalid API key) |
+| `413` | Payload too large (>2 MB) |
+| `429` | Rate limit exceeded |
+
+## Production Deployment
+
+```bash
+export EPHEMERALML_VERIFIER_API_KEY="$(openssl rand -hex 32)"
+export EPHEMERALML_VERIFIER_RATE_LIMIT=60
+
+ephemeralml-verifier \
+  --cors-origin https://your-app.example.com \
+  --port 8080
+```
+
+## Security Defaults Summary
+
+| Feature | Default | Override |
+|---------|---------|---------|
+| Auth | Required (fail-closed) | `--insecure-no-auth` |
+| Rate limit | 60 req/min/IP | `--rate-limit N` (0=off) |
+| CORS | Explicit origins with auth | `--allow-permissive-cors` |
+| Body limit | 2 MB | Not configurable |

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ephemeral-ml-enclave"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 default-run = "ephemeral-ml-enclave"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ephemeral-ml-host"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/verifier-api/Cargo.toml
+++ b/verifier-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ephemeralml-verifier-api"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "Hosted verification API for EphemeralML attested execution receipts"
@@ -32,7 +32,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # CLI
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 
 [dev-dependencies]
 reqwest = { version = "0.13", features = ["json", "multipart"] }

--- a/verifier-api/src/api_types.rs
+++ b/verifier-api/src/api_types.rs
@@ -17,6 +17,12 @@ pub struct VerifyRequest {
     /// Expected measurement type. Default "any" (skip).
     #[serde(default = "default_measurement_type")]
     pub measurement_type: String,
+    /// Expected attestation source (e.g. "cs-tdx", "aws-nitro"). Optional.
+    #[serde(default)]
+    pub expected_attestation_source: Option<String>,
+    /// Expected container image digest (e.g. "sha256:abc123"). Optional.
+    #[serde(default)]
+    pub expected_image_digest: Option<String>,
 }
 
 fn default_measurement_type() -> String {

--- a/verifier-api/src/auth.rs
+++ b/verifier-api/src/auth.rs
@@ -1,0 +1,60 @@
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+
+use crate::api_types::ErrorResponse;
+use crate::AppState;
+
+/// API key authentication middleware.
+///
+/// Checks `Authorization: Bearer <key>` or `X-API-Key: <key>` headers.
+/// Skips auth for health and landing page endpoints.
+pub async fn auth_middleware(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let expected = match &state.api_key {
+        Some(k) => k,
+        None => return next.run(request).await,
+    };
+
+    // Skip auth for health check and landing page
+    let path = request.uri().path();
+    if path == "/health" || path == "/" {
+        return next.run(request).await;
+    }
+
+    let provided = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .or_else(|| {
+            request
+                .headers()
+                .get("x-api-key")
+                .and_then(|v| v.to_str().ok())
+        });
+
+    match provided {
+        Some(key) if key == expected => next.run(request).await,
+        Some(_) => (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse {
+                error: "Invalid API key".to_string(),
+            }),
+        )
+            .into_response(),
+        None => (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse {
+                error: "Missing API key. Provide Authorization: Bearer <key> or X-API-Key: <key>"
+                    .to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}

--- a/verifier-api/src/lib.rs
+++ b/verifier-api/src/lib.rs
@@ -1,23 +1,75 @@
 pub mod api_types;
+pub mod auth;
+pub mod rate_limit;
 pub mod routes;
 pub mod templates;
 
+use axum::middleware;
 use axum::routing::{get, post};
 use axum::Router;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
 
-/// Build the router with permissive CORS (for local dev / tests).
-pub fn build_router() -> Router {
-    build_router_with_cors(CorsLayer::permissive())
+use rate_limit::RateLimiter;
+
+/// Shared application state available to middleware and handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub api_key: Option<String>,
+    pub rate_limiter: Option<RateLimiter>,
 }
 
-/// Build the router with explicit allowed origins.
+/// Server configuration for production deployments.
+pub struct ServerConfig {
+    /// API key for authentication. `None` disables auth.
+    pub api_key: Option<String>,
+    /// Maximum requests per minute per IP. 0 disables rate limiting.
+    pub requests_per_minute: u32,
+    /// Allowed CORS origins. Empty = permissive.
+    pub cors_origins: Vec<String>,
+}
+
+/// Build the router with permissive defaults (for local dev / tests).
 ///
-/// Pass an empty slice to get permissive CORS (not recommended for production).
+/// No auth, no rate limiting, permissive CORS. **Not for production.**
+pub fn build_router() -> Router {
+    let state = AppState {
+        api_key: None,
+        rate_limiter: None,
+    };
+    build_router_inner(CorsLayer::permissive(), state)
+}
+
+/// Build the router with explicit allowed origins (legacy API, no auth/rate limit).
 pub fn build_router_with_origins(origins: &[String]) -> Router {
-    let cors = if origins.is_empty() {
+    let cors = make_cors_layer(origins);
+    let state = AppState {
+        api_key: None,
+        rate_limiter: None,
+    };
+    build_router_inner(cors, state)
+}
+
+/// Build the router with full production configuration.
+pub fn build_router_with_config(config: &ServerConfig) -> Router {
+    let cors = make_cors_layer(&config.cors_origins);
+    let rate_limiter = if config.requests_per_minute > 0 {
+        let limiter = RateLimiter::new(config.requests_per_minute);
+        limiter.spawn_cleanup_task();
+        Some(limiter)
+    } else {
+        None
+    };
+    let state = AppState {
+        api_key: config.api_key.clone(),
+        rate_limiter,
+    };
+    build_router_inner(cors, state)
+}
+
+fn make_cors_layer(origins: &[String]) -> CorsLayer {
+    if origins.is_empty() {
         CorsLayer::permissive()
     } else {
         let parsed: Vec<_> = origins.iter().filter_map(|o| o.parse().ok()).collect();
@@ -25,16 +77,24 @@ pub fn build_router_with_origins(origins: &[String]) -> Router {
             .allow_origin(AllowOrigin::list(parsed))
             .allow_methods(tower_http::cors::Any)
             .allow_headers(tower_http::cors::Any)
-    };
-    build_router_with_cors(cors)
+    }
 }
 
-fn build_router_with_cors(cors: CorsLayer) -> Router {
+fn build_router_inner(cors: CorsLayer, state: AppState) -> Router {
     Router::new()
         .route("/", get(routes::landing_page))
         .route("/health", get(routes::health))
         .route("/api/v1/verify", post(routes::verify_json))
         .route("/api/v1/verify/upload", post(routes::verify_upload))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::auth_middleware,
+        ))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            rate_limit::rate_limit_middleware,
+        ))
+        .with_state(state)
         .layer(cors)
         .layer(RequestBodyLimitLayer::new(2 * 1024 * 1024)) // 2 MB
         .layer(TraceLayer::new_for_http())

--- a/verifier-api/src/main.rs
+++ b/verifier-api/src/main.rs
@@ -16,6 +16,21 @@ struct Args {
     /// Allowed CORS origins (repeatable). If omitted, all origins are allowed.
     #[arg(long = "cors-origin")]
     cors_origins: Vec<String>,
+    /// API key for authenticating verify requests.
+    /// Can also be set via EPHEMERALML_VERIFIER_API_KEY env var.
+    #[arg(long, env = "EPHEMERALML_VERIFIER_API_KEY")]
+    api_key: Option<String>,
+    /// Disable API key authentication. Required when no --api-key is set.
+    /// WARNING: Do not use in production internet-facing deployments.
+    #[arg(long, env = "EPHEMERALML_VERIFIER_NO_AUTH")]
+    insecure_no_auth: bool,
+    /// Maximum requests per minute per IP. Default: 60. Set to 0 to disable.
+    #[arg(long, env = "EPHEMERALML_VERIFIER_RATE_LIMIT", default_value = "60")]
+    rate_limit: u32,
+    /// Allow fully permissive CORS when auth is enabled and no --cors-origin
+    /// is specified. Not recommended for production.
+    #[arg(long)]
+    allow_permissive_cors: bool,
 }
 
 #[tokio::main]
@@ -28,17 +43,79 @@ async fn main() {
         )
         .init();
 
-    let app = if args.cors_origins.is_empty() {
+    // --- Auth validation ---
+    let api_key = match (&args.api_key, args.insecure_no_auth) {
+        (Some(key), _) => {
+            if key.len() < 16 {
+                tracing::warn!(
+                    "API key is shorter than 16 characters — consider using a stronger key"
+                );
+            }
+            tracing::info!("API key authentication enabled");
+            Some(key.clone())
+        }
+        (None, true) => {
+            tracing::warn!("========================================");
+            tracing::warn!("  AUTH DISABLED (--insecure-no-auth)");
+            tracing::warn!("  Do NOT expose this to the internet!");
+            tracing::warn!("========================================");
+            None
+        }
+        (None, false) => {
+            eprintln!(
+                "Error: No API key configured. Either:\n\
+                 \n\
+                 1. Set an API key:  --api-key <KEY>  or  EPHEMERALML_VERIFIER_API_KEY=<KEY>\n\
+                 2. Explicitly disable auth:  --insecure-no-auth\n\
+                 \n\
+                 This is required to prevent accidental unauthenticated deployments."
+            );
+            std::process::exit(1);
+        }
+    };
+
+    // --- CORS validation ---
+    if args.cors_origins.is_empty() {
+        if api_key.is_some() && !args.allow_permissive_cors {
+            eprintln!(
+                "Error: Auth is enabled but no --cors-origin specified.\n\
+                 \n\
+                 Either:\n\
+                 1. Specify allowed origins:  --cors-origin https://your-app.example.com\n\
+                 2. Explicitly allow permissive CORS:  --allow-permissive-cors\n\
+                 \n\
+                 Fully permissive CORS with auth enabled is not recommended."
+            );
+            std::process::exit(1);
+        }
         tracing::warn!("No --cors-origin specified; CORS is fully permissive");
-        ephemeralml_verifier_api::build_router()
     } else {
         tracing::info!("CORS allowed origins: {:?}", args.cors_origins);
-        ephemeralml_verifier_api::build_router_with_origins(&args.cors_origins)
+    }
+
+    // --- Rate limit ---
+    if args.rate_limit == 0 {
+        tracing::warn!("Rate limiting is disabled (--rate-limit 0)");
+    } else {
+        tracing::info!("Rate limit: {} requests/minute per IP", args.rate_limit);
+    }
+
+    let config = ephemeralml_verifier_api::ServerConfig {
+        api_key,
+        requests_per_minute: args.rate_limit,
+        cors_origins: args.cors_origins,
     };
+
+    let app = ephemeralml_verifier_api::build_router_with_config(&config);
 
     let addr = format!("{}:{}", args.host, args.port);
     tracing::info!("EphemeralML Verifier API listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await
+    .unwrap();
 }

--- a/verifier-api/src/rate_limit.rs
+++ b/verifier-api/src/rate_limit.rs
@@ -1,0 +1,115 @@
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::Mutex;
+
+use crate::api_types::ErrorResponse;
+use crate::AppState;
+
+/// Per-IP sliding window rate limiter.
+///
+/// Tracks request counts per IP within a 60-second window.
+/// When the limit is exceeded, returns 429 Too Many Requests.
+#[derive(Clone)]
+pub struct RateLimiter {
+    requests_per_minute: u32,
+    clients: Arc<Mutex<HashMap<IpAddr, WindowEntry>>>,
+}
+
+struct WindowEntry {
+    count: u32,
+    window_start: Instant,
+}
+
+impl RateLimiter {
+    pub fn new(requests_per_minute: u32) -> Self {
+        Self {
+            requests_per_minute,
+            clients: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Check if the given IP is within the rate limit.
+    pub async fn check(&self, ip: IpAddr) -> bool {
+        let mut clients = self.clients.lock().await;
+        let now = Instant::now();
+
+        let entry = clients.entry(ip).or_insert(WindowEntry {
+            count: 0,
+            window_start: now,
+        });
+
+        if now.duration_since(entry.window_start) > std::time::Duration::from_secs(60) {
+            entry.count = 1;
+            entry.window_start = now;
+            true
+        } else {
+            entry.count += 1;
+            entry.count <= self.requests_per_minute
+        }
+    }
+
+    /// Periodically clean up expired entries to prevent unbounded memory growth.
+    pub fn spawn_cleanup_task(&self) {
+        let clients = self.clients.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
+            loop {
+                interval.tick().await;
+                let mut map = clients.lock().await;
+                let now = Instant::now();
+                map.retain(|_, entry| {
+                    now.duration_since(entry.window_start) < std::time::Duration::from_secs(120)
+                });
+            }
+        });
+    }
+}
+
+/// Extract client IP from request extensions (ConnectInfo) or fall back to 0.0.0.0.
+fn extract_ip(request: &Request) -> IpAddr {
+    request
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip())
+        .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED))
+}
+
+/// Rate limiting middleware.
+///
+/// Skips rate limiting for health checks.
+pub async fn rate_limit_middleware(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let limiter = match &state.rate_limiter {
+        Some(l) => l,
+        None => return next.run(request).await,
+    };
+
+    // Skip rate limiting for health endpoint
+    if request.uri().path() == "/health" {
+        return next.run(request).await;
+    }
+
+    let ip = extract_ip(&request);
+
+    if limiter.check(ip).await {
+        next.run(request).await
+    } else {
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(ErrorResponse {
+                error: "Rate limit exceeded. Try again later.".to_string(),
+            }),
+        )
+            .into_response()
+    }
+}


### PR DESCRIPTION
## Summary

- **API key auth** on verify endpoints (`Authorization: Bearer` / `X-API-Key`). Fail-closed startup: no key + no `--insecure-no-auth` = error exit.
- **Per-IP rate limiting** (60 req/min default). Configurable via `--rate-limit` / `EPHEMERALML_VERIFIER_RATE_LIMIT`. Health exempt.
- **CORS tightening**: auth + no `--cors-origin` = startup fails unless `--allow-permissive-cors`.
- **New policy fields**: `expected_attestation_source` and `expected_image_digest` on JSON + multipart endpoints. Wired into `VerifyOptions`.
- **22 tests** (12 new): auth success/failure, rate limit enforcement, policy field acceptance/skip, backward compatibility.
- **`docs/verifier-api.md`**: auth, rate limits, policy fields, curl examples, security defaults table.

## Security defaults

| Feature | Default | Override |
|---------|---------|---------|
| Auth | Required (fail-closed) | `--insecure-no-auth` |
| Rate limit | 60 req/min/IP | `--rate-limit N` (0=off) |
| CORS | Explicit origins with auth | `--allow-permissive-cors` |
| Body limit | 2 MB | Not configurable |

## New env vars / flags

| Env Var | CLI Flag | Purpose |
|---------|----------|---------|
| `EPHEMERALML_VERIFIER_API_KEY` | `--api-key` | API key |
| `EPHEMERALML_VERIFIER_NO_AUTH` | `--insecure-no-auth` | Disable auth |
| `EPHEMERALML_VERIFIER_RATE_LIMIT` | `--rate-limit` | Req/min/IP |
| — | `--allow-permissive-cors` | Override CORS fail-closed |

## Test plan

- [x] `cargo test --workspace` — all pass
- [x] `cargo test -p ephemeralml-verifier-api` — 22/22 pass
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `bash -n scripts/gcp/*.sh scripts/lib/ui.sh` — clean

## Breaking changes

None. All new fields are optional with defaults preserving old behavior.

## Files changed (16)

| File | Change |
|------|--------|
| `verifier-api/src/auth.rs` | **New** — auth middleware |
| `verifier-api/src/rate_limit.rs` | **New** — rate limiter + middleware |
| `verifier-api/src/lib.rs` | AppState, ServerConfig, build_router_with_config |
| `verifier-api/src/main.rs` | CLI args, startup validation |
| `verifier-api/src/api_types.rs` | New policy fields |
| `verifier-api/src/routes.rs` | Wire fields into VerifyOptions |
| `verifier-api/Cargo.toml` | clap env feature, version bump |
| `verifier-api/tests/api_test.rs` | 12 new tests |
| `docs/verifier-api.md` | **New** — full API docs |
| `CHANGELOG.md` | v0.2.5 entry |
| `*/Cargo.toml` (6 crates) | Version 0.2.4 → 0.2.5 |
| `Cargo.lock` | Updated |