### PR TITLE
feat(cli): native `ephemeralml gcp` workflow with fail-closed preflight

### DIFF
--- a/client/src/gcp/commands.rs
+++ b/client/src/gcp/commands.rs
@@ -1,0 +1,460 @@
+use anyhow::Result;
+
+use ephemeral_ml_common::ui::Ui;
+
+use super::config::{find_project_dir, GcpConfig, GcpFlags};
+use super::doctor::run_doctor;
+use super::preflight::run_preflight;
+use super::runner::ScriptRunner;
+
+/// Run preflight, but skip (with warning) when dry_run is true.
+fn preflight_or_dry_run(ui: &mut Ui, config: &GcpConfig) -> Result<()> {
+    if config.dry_run {
+        ui.warn("--dry-run: skipping preflight checks (auth, disk, project)");
+        return Ok(());
+    }
+    run_preflight(config)
+}
+
+/// Print a "Next:" guidance line after a successful command.
+fn next_step(ui: &mut Ui, msg: &str) {
+    ui.blank();
+    ui.info(&format!("Next: {}", msg));
+}
+
+/// Print structured JSON status if --json is set.
+fn json_status(config: &GcpConfig, command: &str, success: bool, detail: &str) {
+    if config.json {
+        let status = if success { "ok" } else { "error" };
+        println!(
+            r#"{{"command":"gcp {}","status":"{}","detail":"{}"}}"#,
+            command,
+            status,
+            detail.replace('"', "\\\"")
+        );
+    }
+}
+
+/// Run `ephemeralml gcp doctor`.
+pub fn cmd_doctor(ui: &mut Ui) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let ok = run_doctor(ui, &project_dir)?;
+    if ok {
+        next_step(ui, "ephemeralml gcp init  (configure GCP project)");
+    }
+    if !ok {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Run `ephemeralml gcp init`.
+pub fn cmd_init(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    use anyhow::{bail, Context};
+    use std::process::{Command, Stdio};
+
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+
+    // init_gcp.sh lives at scripts/init_gcp.sh (not scripts/gcp/)
+    let script_path = project_dir.join("scripts").join("init_gcp.sh");
+    if !script_path.exists() {
+        bail!(
+            "Script not found: init_gcp.sh. Expected at {}",
+            script_path.display()
+        );
+    }
+
+    let mut args: Vec<&str> = Vec::new();
+    if config.non_interactive {
+        args.push("--non-interactive");
+    }
+
+    ui.info("Initializing GCP configuration...");
+    ui.blank();
+
+    if config.dry_run {
+        let args_display = if args.is_empty() {
+            String::new()
+        } else {
+            format!(" {}", args.join(" "))
+        };
+        println!("[dry-run] bash {}{}", script_path.display(), args_display);
+        json_status(&config, "init", true, "dry-run");
+        next_step(ui, "ephemeralml gcp setup  (provision GCP infrastructure)");
+        return Ok(());
+    }
+
+    let mut cmd = Command::new("bash");
+    cmd.arg(&script_path);
+    cmd.args(&args);
+    cmd.stdout(Stdio::inherit());
+    cmd.stderr(Stdio::inherit());
+    cmd.current_dir(&project_dir);
+    // Pass through all resolved config as env vars so non-interactive mode picks them up
+    if !config.project.is_empty() {
+        cmd.env("EPHEMERALML_GCP_PROJECT", &config.project);
+    }
+    if !config.zone.is_empty() {
+        cmd.env("EPHEMERALML_GCP_ZONE", &config.zone);
+    }
+    if !config.region.is_empty() {
+        cmd.env("EPHEMERALML_GCP_REGION", &config.region);
+    }
+    if !config.bucket.is_empty() {
+        cmd.env("EPHEMERALML_GCS_BUCKET", &config.bucket);
+    }
+    if !config.model_source.is_empty() {
+        cmd.env("EPHEMERALML_MODEL_SOURCE", &config.model_source);
+    }
+    if let Some(ref key) = config.kms_key {
+        cmd.env("EPHEMERALML_GCP_KMS_KEY", key);
+    }
+    if let Some(ref aud) = config.wip_audience {
+        cmd.env("EPHEMERALML_GCP_WIP_AUDIENCE", aud);
+    }
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("Failed to execute {}", script_path.display()))?;
+
+    if !status.success() {
+        let code = status.code().unwrap_or(-1);
+        bail!("init_gcp.sh exited with code {}", code);
+    }
+
+    json_status(&config, "init", true, "config generated");
+    next_step(ui, "ephemeralml gcp setup  (provision GCP infrastructure)");
+    Ok(())
+}
+
+/// Run `ephemeralml gcp setup`.
+pub fn cmd_setup(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+    preflight_or_dry_run(ui, &config)?;
+
+    let runner = ScriptRunner::new(project_dir);
+    let mut args: Vec<&str> = Vec::new();
+    if !config.project.is_empty() {
+        args.push("--project");
+        args.push(&config.project);
+    }
+    let source_ranges_clone;
+    if let Some(ref sr) = config.source_ranges {
+        source_ranges_clone = sr.clone();
+        args.push("--source-ranges");
+        args.push(&source_ranges_clone);
+    }
+
+    ui.info("Running GCP infrastructure setup...");
+    ui.blank();
+    let result = runner.run("setup.sh", &args, &config, config.dry_run);
+    if result.is_ok() {
+        json_status(&config, "setup", true, "infrastructure provisioned");
+        next_step(ui, "ephemeralml gcp setup-kms  (configure KMS + WIP)");
+    }
+    result
+}
+
+/// Build positional args for setup_kms.sh: PROJECT REGION [DIGEST|--allow-broad-binding].
+///
+/// Returns `Err` if neither `--image-digest` nor `--allow-broad-binding` is set.
+pub(crate) fn build_setup_kms_args(config: &GcpConfig) -> Result<Vec<String>> {
+    use anyhow::bail;
+
+    if !config.allow_broad_binding && config.image_digest.is_none() {
+        bail!(
+            "setup-kms requires either --image-digest <sha256:DIGEST> or --allow-broad-binding.\n\
+             Production: ephemeralml gcp setup-kms --image-digest sha256:abc123...\n\
+             Development: ephemeralml gcp setup-kms --allow-broad-binding"
+        );
+    }
+
+    let mut args: Vec<String> = vec![config.project.clone(), config.region.clone()];
+    if config.allow_broad_binding {
+        args.push("--allow-broad-binding".to_string());
+    } else if let Some(ref digest) = config.image_digest {
+        args.push(digest.clone());
+    }
+    Ok(args)
+}
+
+/// Run `ephemeralml gcp setup-kms`.
+pub fn cmd_setup_kms(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+    preflight_or_dry_run(ui, &config)?;
+
+    let args = build_setup_kms_args(&config)?;
+
+    let runner = ScriptRunner::new(project_dir);
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    ui.info("Setting up Cloud KMS + Workload Identity Pool...");
+    if config.verbose {
+        ui.info(&format!("  Project: {}", config.project));
+        ui.info(&format!("  Region:  {}", config.region));
+    }
+    ui.blank();
+    let result = runner.run("setup_kms.sh", &args_refs, &config, config.dry_run);
+    if result.is_ok() {
+        json_status(&config, "setup-kms", true, "KMS and WIP configured");
+        next_step(
+            ui,
+            "ephemeralml gcp package-model  (encrypt, sign, upload model)",
+        );
+    }
+    result
+}
+
+/// Run `ephemeralml gcp package-model`.
+pub fn cmd_package_model(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+    preflight_or_dry_run(ui, &config)?;
+
+    let runner = ScriptRunner::new(project_dir);
+
+    // package_model.sh takes: <model_dir> <gcs_prefix> [--model-id ID] [--version VER] [--format FMT] [--dry-run]
+    let model_dir = config.model_dir.as_deref().unwrap_or("test_assets/minilm");
+    let mut args: Vec<String> = vec![model_dir.to_string(), config.model_prefix.clone()];
+    if let Some(ref id) = config.model_id {
+        args.push("--model-id".to_string());
+        args.push(id.clone());
+    }
+    if let Some(ref ver) = config.model_version {
+        args.push("--version".to_string());
+        args.push(ver.clone());
+    }
+    args.push("--format".to_string());
+    args.push(config.model_format.clone());
+    if config.dry_run {
+        args.push("--dry-run".to_string());
+    }
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    ui.info("Packaging model (encrypt, sign, upload)...");
+    ui.blank();
+    let result = runner.run("package_model.sh", &args_refs, &config, false);
+    if result.is_ok() {
+        json_status(&config, "package-model", true, "model packaged");
+        next_step(
+            ui,
+            "ephemeralml gcp deploy  (launch Confidential Space CVM)",
+        );
+    }
+    result
+}
+
+/// Run `ephemeralml gcp deploy`.
+pub fn cmd_deploy(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+    preflight_or_dry_run(ui, &config)?;
+
+    let runner = ScriptRunner::new(project_dir);
+
+    let mut args: Vec<String> = vec![
+        "--project".to_string(),
+        config.project.clone(),
+        "--zone".to_string(),
+        config.zone.clone(),
+    ];
+    if config.gpu {
+        args.push("--gpu".to_string());
+    }
+    if config.debug {
+        args.push("--debug".to_string());
+    }
+    if config.skip_build {
+        args.push("--skip-build".to_string());
+    }
+    if config.yes {
+        args.push("--yes".to_string());
+    }
+    if let Some(ref tag) = config.tag {
+        args.push("--tag".to_string());
+        args.push(tag.clone());
+    }
+    args.push("--model-source".to_string());
+    args.push(config.model_source.clone());
+    if let Some(ref key) = config.kms_key {
+        args.push("--kms-key".to_string());
+        args.push(key.clone());
+    }
+    if let Some(ref aud) = config.wip_audience {
+        args.push("--wip-audience".to_string());
+        args.push(aud.clone());
+    }
+    args.push("--bucket".to_string());
+    args.push(config.bucket.clone());
+    args.push("--model-prefix".to_string());
+    args.push(config.model_prefix.clone());
+    if let Some(ref hash) = config.model_hash {
+        args.push("--model-hash".to_string());
+        args.push(hash.clone());
+    }
+    if let Some(ref pk) = config.model_signing_pubkey {
+        args.push("--model-signing-pubkey".to_string());
+        args.push(pk.clone());
+    }
+    args.push("--model-format".to_string());
+    args.push(config.model_format.clone());
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let mode = if config.gpu { "GPU" } else { "CPU" };
+    ui.info(&format!(
+        "Deploying Confidential Space CVM ({} mode)...",
+        mode
+    ));
+    if config.verbose {
+        ui.info(&format!("  Project: {}", config.project));
+        ui.info(&format!("  Zone:    {}", config.zone));
+        ui.info(&format!("  Region:  {}", config.region));
+    }
+    ui.blank();
+    let result = runner.run("deploy.sh", &args_refs, &config, config.dry_run);
+    if result.is_ok() {
+        json_status(&config, "deploy", true, &format!("{} CVM launched", mode));
+        next_step(ui, "ephemeralml gcp verify  (smoke test the deployment)");
+    }
+    result
+}
+
+/// Run `ephemeralml gcp verify`.
+pub fn cmd_verify(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+
+    let runner = ScriptRunner::new(project_dir);
+
+    let mut args: Vec<String> = Vec::new();
+    if let Some(ref ip) = config.ip {
+        args.push("--ip".to_string());
+        args.push(ip.clone());
+    }
+    args.push("--project".to_string());
+    args.push(config.project.clone());
+    args.push("--zone".to_string());
+    args.push(config.zone.clone());
+    if config.gpu {
+        args.push("--gpu".to_string());
+    }
+    if config.allow_unpinned_audience {
+        args.push("--allow-unpinned-audience".to_string());
+    }
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    ui.info("Verifying deployed CVM...");
+    ui.blank();
+    let result = runner.run("verify.sh", &args_refs, &config, config.dry_run);
+    if result.is_ok() {
+        json_status(&config, "verify", true, "CVM verified");
+        next_step(ui, "ephemeralml gcp teardown  (when done, delete the CVM)");
+    }
+    result
+}
+
+/// Run `ephemeralml gcp teardown`.
+pub fn cmd_teardown(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+
+    let runner = ScriptRunner::new(project_dir);
+
+    let mut args: Vec<String> = vec![
+        "--project".to_string(),
+        config.project.clone(),
+        "--zone".to_string(),
+        config.zone.clone(),
+    ];
+    if config.gpu {
+        args.push("--gpu".to_string());
+    }
+    if config.yes {
+        args.push("--yes".to_string());
+    }
+    if config.delete_image {
+        args.push("--delete-image".to_string());
+    }
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    ui.info("Tearing down Confidential Space CVM...");
+    ui.blank();
+    let result = runner.run("teardown.sh", &args_refs, &config, config.dry_run);
+    if result.is_ok() {
+        json_status(&config, "teardown", true, "CVM deleted");
+        next_step(
+            ui,
+            "deployment cleaned up. Re-deploy with: ephemeralml gcp deploy",
+        );
+    }
+    result
+}
+
+/// Run `ephemeralml gcp e2e`.
+pub fn cmd_e2e(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+    preflight_or_dry_run(ui, &config)?;
+
+    let runner = ScriptRunner::new(project_dir);
+
+    let mut args: Vec<String> = vec![
+        "--project".to_string(),
+        config.project.clone(),
+        "--zone".to_string(),
+        config.zone.clone(),
+    ];
+    if config.cpu_only {
+        args.push("--cpu-only".to_string());
+    }
+    if config.skip_setup {
+        args.push("--skip-setup".to_string());
+    }
+    if config.skip_teardown {
+        args.push("--skip-teardown".to_string());
+    }
+    if let Some(ref dir) = config.model_dir {
+        args.push("--model-dir".to_string());
+        args.push(dir.clone());
+    }
+    args.push("--model-format".to_string());
+    args.push(config.model_format.clone());
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    ui.info("Running full end-to-end pipeline...");
+    ui.blank();
+    let result = runner.run("mvp_gpu_e2e.sh", &args_refs, &config, config.dry_run);
+    if result.is_ok() {
+        json_status(&config, "e2e", true, "pipeline complete");
+        next_step(
+            ui,
+            "check evidence/ directory for receipts and compliance bundle",
+        );
+    }
+    result
+}
+
+/// Run `ephemeralml gcp release-gate`.
+pub fn cmd_release_gate(ui: &mut Ui, flags: GcpFlags) -> Result<()> {
+    let project_dir = find_project_dir()?;
+    let config = GcpConfig::resolve(&flags, &project_dir)?;
+
+    let runner = ScriptRunner::new(project_dir);
+
+    let mut args: Vec<&str> = Vec::new();
+    if config.quick {
+        args.push("--quick");
+    }
+
+    ui.info("Running release gate checks...");
+    ui.blank();
+    let result = runner.run("release_gate.sh", &args, &config, config.dry_run);
+    if result.is_ok() {
+        json_status(&config, "release-gate", true, "all checks passed");
+        next_step(ui, "ready to tag and release");
+    }
+    result
+}

--- a/client/src/gcp/config.rs
+++ b/client/src/gcp/config.rs
@@ -1,0 +1,484 @@
+use anyhow::{bail, Result};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Resolved GCP deployment configuration.
+///
+/// Resolution precedence: CLI flags > env vars > `.env.gcp` file > hardcoded defaults.
+#[derive(Debug, Clone)]
+pub struct GcpConfig {
+    pub project: String,
+    pub region: String,
+    pub zone: String,
+    pub gpu: bool,
+    pub debug: bool,
+    pub kms_key: Option<String>,
+    pub wip_audience: Option<String>,
+    pub bucket: String,
+    pub model_prefix: String,
+    pub model_source: String,
+    pub model_dir: Option<String>,
+    pub model_id: Option<String>,
+    pub model_version: Option<String>,
+    pub model_format: String,
+    pub model_hash: Option<String>,
+    pub model_signing_pubkey: Option<String>,
+    pub tag: Option<String>,
+    pub skip_build: bool,
+    pub yes: bool,
+    pub dry_run: bool,
+    pub ip: Option<String>,
+    pub source_ranges: Option<String>,
+    pub allow_broad_binding: bool,
+    pub image_digest: Option<String>,
+    pub delete_image: bool,
+    pub allow_unpinned_audience: bool,
+    pub skip_setup: bool,
+    pub skip_teardown: bool,
+    pub cpu_only: bool,
+    pub verbose: bool,
+    pub json: bool,
+    pub quick: bool,
+    pub non_interactive: bool,
+}
+
+/// CLI flags that override env/file values. `None` means "not provided".
+#[derive(Debug, Default)]
+pub struct GcpFlags {
+    pub project: Option<String>,
+    pub region: Option<String>,
+    pub zone: Option<String>,
+    pub gpu: bool,
+    pub debug: bool,
+    pub kms_key: Option<String>,
+    pub wip_audience: Option<String>,
+    pub bucket: Option<String>,
+    pub model_prefix: Option<String>,
+    pub model_source: Option<String>,
+    pub model_dir: Option<String>,
+    pub model_id: Option<String>,
+    pub model_version: Option<String>,
+    pub model_format: Option<String>,
+    pub model_hash: Option<String>,
+    pub model_signing_pubkey: Option<String>,
+    pub tag: Option<String>,
+    pub skip_build: bool,
+    pub yes: bool,
+    pub dry_run: bool,
+    pub ip: Option<String>,
+    pub source_ranges: Option<String>,
+    pub allow_broad_binding: bool,
+    pub image_digest: Option<String>,
+    pub delete_image: bool,
+    pub allow_unpinned_audience: bool,
+    pub skip_setup: bool,
+    pub skip_teardown: bool,
+    pub cpu_only: bool,
+    pub verbose: bool,
+    pub json: bool,
+    pub quick: bool,
+    pub non_interactive: bool,
+}
+
+/// Derive a GCP region from a zone (e.g. `us-central1-a` -> `us-central1`).
+///
+/// GCP zones are `<region>-<single-letter>`, e.g. `us-central1-a`.
+/// If the input is already a region (no single-letter suffix), returns it as-is.
+pub fn region_from_zone(zone: &str) -> String {
+    match zone.rfind('-') {
+        // Only strip the suffix if it's a single character (zone letter like -a, -b, -f)
+        Some(pos) if pos > 0 && zone.len() == pos + 2 => zone[..pos].to_string(),
+        _ => zone.to_string(),
+    }
+}
+
+impl GcpConfig {
+    /// Resolve configuration from flags, environment, and `.env.gcp` file.
+    pub fn resolve(flags: &GcpFlags, project_dir: &Path) -> Result<Self> {
+        let file_vars = parse_env_file(&project_dir.join(".env.gcp"));
+
+        let get = |flag: &Option<String>, env_names: &[&str], file_key: &str| -> Option<String> {
+            if let Some(v) = flag {
+                return Some(v.clone());
+            }
+            for name in env_names {
+                if let Ok(v) = std::env::var(name) {
+                    if !v.is_empty() {
+                        return Some(v);
+                    }
+                }
+            }
+            file_vars.get(file_key).cloned()
+        };
+
+        let project = get(
+            &flags.project,
+            &["EPHEMERALML_GCP_PROJECT", "GOOGLE_CLOUD_PROJECT"],
+            "EPHEMERALML_GCP_PROJECT",
+        )
+        .unwrap_or_default();
+
+        let zone = get(
+            &flags.zone,
+            &["EPHEMERALML_GCP_ZONE"],
+            "EPHEMERALML_GCP_ZONE",
+        )
+        .unwrap_or_else(|| "us-central1-a".to_string());
+
+        // Region: explicit flag > env > derived from zone
+        let region = get(
+            &flags.region,
+            &["EPHEMERALML_GCP_REGION"],
+            "EPHEMERALML_GCP_REGION",
+        )
+        .unwrap_or_else(|| region_from_zone(&zone));
+
+        let bucket = get(
+            &flags.bucket,
+            &["EPHEMERALML_GCS_BUCKET", "GCP_BUCKET"],
+            "EPHEMERALML_GCS_BUCKET",
+        )
+        .unwrap_or_else(|| "ephemeralml-models".to_string());
+
+        let model_prefix = get(
+            &flags.model_prefix,
+            &["EPHEMERALML_GCP_MODEL_PREFIX"],
+            "EPHEMERALML_GCP_MODEL_PREFIX",
+        )
+        .unwrap_or_else(|| "models/minilm".to_string());
+
+        let model_source = get(
+            &flags.model_source,
+            &["EPHEMERALML_MODEL_SOURCE"],
+            "EPHEMERALML_MODEL_SOURCE",
+        )
+        .unwrap_or_else(|| "local".to_string());
+
+        let model_format = get(
+            &flags.model_format,
+            &["EPHEMERALML_MODEL_FORMAT"],
+            "EPHEMERALML_MODEL_FORMAT",
+        )
+        .unwrap_or_else(|| "safetensors".to_string());
+
+        let kms_key = get(
+            &flags.kms_key,
+            &["EPHEMERALML_GCP_KMS_KEY", "GCP_KMS_KEY"],
+            "EPHEMERALML_GCP_KMS_KEY",
+        );
+
+        let wip_audience = get(
+            &flags.wip_audience,
+            &["EPHEMERALML_GCP_WIP_AUDIENCE", "GCP_WIP_AUDIENCE"],
+            "EPHEMERALML_GCP_WIP_AUDIENCE",
+        );
+
+        let model_hash = get(
+            &flags.model_hash,
+            &["EPHEMERALML_EXPECTED_MODEL_HASH"],
+            "EPHEMERALML_EXPECTED_MODEL_HASH",
+        );
+
+        let model_signing_pubkey = get(
+            &flags.model_signing_pubkey,
+            &["EPHEMERALML_MODEL_SIGNING_PUBKEY"],
+            "EPHEMERALML_MODEL_SIGNING_PUBKEY",
+        );
+
+        let source_ranges = get(
+            &flags.source_ranges,
+            &["EPHEMERALML_FIREWALL_SOURCE_RANGES"],
+            "EPHEMERALML_FIREWALL_SOURCE_RANGES",
+        );
+
+        Ok(Self {
+            project,
+            region,
+            zone,
+            gpu: flags.gpu,
+            debug: flags.debug,
+            kms_key,
+            wip_audience,
+            bucket,
+            model_prefix,
+            model_source,
+            model_dir: flags.model_dir.clone(),
+            model_id: flags.model_id.clone(),
+            model_version: flags.model_version.clone(),
+            model_format,
+            model_hash,
+            model_signing_pubkey,
+            tag: flags.tag.clone(),
+            skip_build: flags.skip_build,
+            yes: flags.yes,
+            dry_run: flags.dry_run,
+            ip: flags.ip.clone(),
+            source_ranges,
+            allow_broad_binding: flags.allow_broad_binding,
+            image_digest: flags.image_digest.clone(),
+            delete_image: flags.delete_image,
+            allow_unpinned_audience: flags.allow_unpinned_audience,
+            skip_setup: flags.skip_setup,
+            skip_teardown: flags.skip_teardown,
+            cpu_only: flags.cpu_only,
+            verbose: flags.verbose,
+            json: flags.json,
+            quick: flags.quick,
+            non_interactive: flags.non_interactive,
+        })
+    }
+
+    /// Require that the project field is non-empty, or bail.
+    pub fn require_project(&self) -> Result<&str> {
+        if self.project.is_empty() {
+            bail!(
+                "GCP project is required. Set --project, EPHEMERALML_GCP_PROJECT, \
+                 or add it to .env.gcp"
+            );
+        }
+        Ok(&self.project)
+    }
+}
+
+/// Parse a `.env.gcp` file into key-value pairs.
+///
+/// Accepts both `KEY=VALUE` and `export KEY=VALUE` formats (as produced by
+/// `scripts/init_gcp.sh`). Lines starting with `#` or empty lines are skipped.
+/// Values may optionally be quoted with single or double quotes.
+pub fn parse_env_file(path: &Path) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return map,
+    };
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // Strip leading `export ` prefix (init_gcp.sh writes `export KEY="value"`)
+        let assignment = if let Some(rest) = trimmed.strip_prefix("export ") {
+            rest.trim()
+        } else {
+            trimmed
+        };
+        if let Some((key, value)) = assignment.split_once('=') {
+            let key = key.trim();
+            let mut value = value.trim();
+            // Strip optional quotes
+            if ((value.starts_with('"') && value.ends_with('"'))
+                || (value.starts_with('\'') && value.ends_with('\'')))
+                && value.len() >= 2
+            {
+                value = &value[1..value.len() - 1];
+            }
+            if !key.is_empty() {
+                map.insert(key.to_string(), value.to_string());
+            }
+        }
+    }
+    map
+}
+
+/// Find the project root directory by searching for Cargo.toml upward from the current dir.
+pub fn find_project_dir() -> Result<PathBuf> {
+    let mut dir = std::env::current_dir()?;
+    loop {
+        if dir.join("Cargo.toml").exists() && dir.join("scripts").exists() {
+            return Ok(dir);
+        }
+        if !dir.pop() {
+            bail!(
+                "Could not find EphemeralML project root (looked for Cargo.toml + scripts/). \
+                 Run from within the project directory."
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn temp_dir() -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "ephemeralml_config_test_{}_{}",
+            std::process::id(),
+            nanos
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parse_env_file_basic() {
+        let dir = temp_dir();
+        let path = dir.join(".env.gcp");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "# comment").unwrap();
+        writeln!(f, "EPHEMERALML_GCP_PROJECT=my-project").unwrap();
+        writeln!(f, "EPHEMERALML_GCP_ZONE=\"us-west1-b\"").unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, "EPHEMERALML_GCS_BUCKET='my-bucket'").unwrap();
+        drop(f);
+
+        let vars = parse_env_file(&path);
+        assert_eq!(vars.get("EPHEMERALML_GCP_PROJECT").unwrap(), "my-project");
+        assert_eq!(vars.get("EPHEMERALML_GCP_ZONE").unwrap(), "us-west1-b");
+        assert_eq!(vars.get("EPHEMERALML_GCS_BUCKET").unwrap(), "my-bucket");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_env_file_missing_returns_empty() {
+        let vars = parse_env_file(Path::new("/nonexistent/.env.gcp"));
+        assert!(vars.is_empty());
+    }
+
+    #[test]
+    fn flags_override_env_file() {
+        let dir = temp_dir();
+        let path = dir.join(".env.gcp");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "EPHEMERALML_GCP_PROJECT=file-project").unwrap();
+        writeln!(f, "EPHEMERALML_GCS_BUCKET=file-bucket").unwrap();
+        drop(f);
+
+        let flags = GcpFlags {
+            project: Some("flag-project".to_string()),
+            ..Default::default()
+        };
+        let config = GcpConfig::resolve(&flags, &dir).unwrap();
+        assert_eq!(config.project, "flag-project");
+        // bucket should come from file since no flag or env var set
+        // (env var may or may not be set in test environment, so we just check it's not empty)
+        assert!(!config.bucket.is_empty());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn defaults_applied_when_nothing_set() {
+        let dir = temp_dir();
+        let flags = GcpFlags::default();
+        let config = GcpConfig::resolve(&flags, &dir).unwrap();
+        assert_eq!(config.zone, "us-central1-a");
+        assert_eq!(config.bucket, "ephemeralml-models");
+        assert_eq!(config.model_prefix, "models/minilm");
+        assert_eq!(config.model_source, "local");
+        assert_eq!(config.model_format, "safetensors");
+        assert!(config.project.is_empty());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn require_project_fails_when_empty() {
+        let dir = temp_dir();
+        let flags = GcpFlags::default();
+        let config = GcpConfig::resolve(&flags, &dir).unwrap();
+        assert!(config.require_project().is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn require_project_ok_when_set() {
+        let dir = temp_dir();
+        let flags = GcpFlags {
+            project: Some("test-proj".to_string()),
+            ..Default::default()
+        };
+        let config = GcpConfig::resolve(&flags, &dir).unwrap();
+        assert_eq!(config.require_project().unwrap(), "test-proj");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_env_file_export_prefix() {
+        let dir = temp_dir();
+        let path = dir.join(".env.gcp");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "export EPHEMERALML_GCP_PROJECT=\"my-project\"").unwrap();
+        writeln!(f, "export EPHEMERALML_GCP_ZONE=\"us-west1-b\"").unwrap();
+        writeln!(f, "export EPHEMERALML_GCS_BUCKET='my-bucket'").unwrap();
+        drop(f);
+
+        let vars = parse_env_file(&path);
+        assert_eq!(vars.get("EPHEMERALML_GCP_PROJECT").unwrap(), "my-project");
+        assert_eq!(vars.get("EPHEMERALML_GCP_ZONE").unwrap(), "us-west1-b");
+        assert_eq!(vars.get("EPHEMERALML_GCS_BUCKET").unwrap(), "my-bucket");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_env_file_mixed_export_and_plain() {
+        let dir = temp_dir();
+        let path = dir.join(".env.gcp");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "# Generated by init_gcp.sh").unwrap();
+        writeln!(f, "export EPHEMERALML_GCP_PROJECT=\"proj-a\"").unwrap();
+        writeln!(f, "PLAIN_KEY=plain-value").unwrap();
+        writeln!(f, "export QUOTED='single-q'").unwrap();
+        drop(f);
+
+        let vars = parse_env_file(&path);
+        assert_eq!(vars.get("EPHEMERALML_GCP_PROJECT").unwrap(), "proj-a");
+        assert_eq!(vars.get("PLAIN_KEY").unwrap(), "plain-value");
+        assert_eq!(vars.get("QUOTED").unwrap(), "single-q");
+        // Ensure "export EPHEMERALML_GCP_PROJECT" is NOT a key
+        assert!(!vars.contains_key("export EPHEMERALML_GCP_PROJECT"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn region_from_zone_derivation() {
+        assert_eq!(region_from_zone("us-central1-a"), "us-central1");
+        assert_eq!(region_from_zone("europe-west4-b"), "europe-west4");
+        assert_eq!(region_from_zone("asia-southeast1-c"), "asia-southeast1");
+        // Edge: no dash at all
+        assert_eq!(region_from_zone("nohyphen"), "nohyphen");
+    }
+
+    #[test]
+    fn config_region_derived_from_zone() {
+        let dir = temp_dir();
+        let flags = GcpFlags {
+            zone: Some("us-west1-b".to_string()),
+            ..Default::default()
+        };
+        let config = GcpConfig::resolve(&flags, &dir).unwrap();
+        assert_eq!(config.zone, "us-west1-b");
+        assert_eq!(config.region, "us-west1");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn config_region_flag_overrides_derivation() {
+        let dir = temp_dir();
+        let flags = GcpFlags {
+            zone: Some("us-west1-b".to_string()),
+            region: Some("europe-west4".to_string()),
+            ..Default::default()
+        };
+        let config = GcpConfig::resolve(&flags, &dir).unwrap();
+        assert_eq!(config.zone, "us-west1-b");
+        assert_eq!(config.region, "europe-west4");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn config_default_region_from_default_zone() {
+        let dir = temp_dir();
+        let flags = GcpFlags::default();
+        let config = GcpConfig::resolve(&flags, &dir).unwrap();
+        assert_eq!(config.zone, "us-central1-a");
+        assert_eq!(config.region, "us-central1");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/client/src/gcp/doctor.rs
+++ b/client/src/gcp/doctor.rs
@@ -1,0 +1,203 @@
+use anyhow::Result;
+use std::path::Path;
+use std::process::Command;
+
+use ephemeral_ml_common::receipt_verify::CheckStatus;
+use ephemeral_ml_common::ui::Ui;
+
+/// Run all doctor checks, returning true if all critical checks pass.
+pub fn run_doctor(ui: &mut Ui, project_dir: &Path) -> Result<bool> {
+    ui.header("EphemeralML GCP Doctor");
+    ui.blank();
+
+    let mut all_ok = true;
+
+    // 1. gcloud installed + version
+    let gcloud_ok = check_tool_version(ui, "gcloud", &["--version"], "Google Cloud SDK");
+    if !gcloud_ok {
+        all_ok = false;
+    }
+
+    // 2. gcloud auth active
+    let auth_ok = check_gcloud_auth(ui);
+    if !auth_ok {
+        all_ok = false;
+    }
+
+    // 3. docker installed + daemon running
+    let docker_ok = check_docker(ui);
+    if !docker_ok {
+        all_ok = false;
+    }
+
+    // 4. cargo / rustc installed
+    let cargo_ok = check_tool_version(ui, "cargo", &["--version"], "Cargo");
+    if !cargo_ok {
+        all_ok = false;
+    }
+
+    // 5. Disk space >= 20GB free (Docker images + build artifacts)
+    let disk_ok = check_disk_space(ui, 20);
+    if !disk_ok {
+        all_ok = false;
+    }
+
+    // 6. .env.gcp file exists (warn only)
+    check_env_file(ui, project_dir);
+
+    // 7. Project ID set
+    let project_ok = check_project_set(ui, project_dir);
+    if !project_ok {
+        // Warn but don't fail — not needed for doctor
+        ui.warn("  Project ID not set (needed for deploy/setup commands)");
+    }
+
+    ui.blank();
+    if all_ok {
+        ui.success("--> All critical checks passed");
+    } else {
+        ui.failure("--> Some checks failed (see above)");
+    }
+    ui.blank();
+
+    Ok(all_ok)
+}
+
+fn check_tool_version(ui: &mut Ui, tool: &str, args: &[&str], label: &str) -> bool {
+    match Command::new(tool).args(args).output() {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stdout);
+            let first_line = ver.lines().next().unwrap_or("(unknown version)");
+            ui.check(&format!("{} installed", label), &CheckStatus::Pass);
+            ui.info(&format!("  {}", first_line.trim()));
+            true
+        }
+        _ => {
+            ui.check(&format!("{} installed", label), &CheckStatus::Fail);
+            ui.info(&format!("  Install {} and ensure it's in PATH", tool));
+            false
+        }
+    }
+}
+
+fn check_gcloud_auth(ui: &mut Ui) -> bool {
+    match Command::new("gcloud")
+        .args(["auth", "print-access-token"])
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            ui.check("gcloud auth active", &CheckStatus::Pass);
+            true
+        }
+        _ => {
+            ui.check("gcloud auth active", &CheckStatus::Fail);
+            ui.info("  Run: gcloud auth login && gcloud auth application-default login");
+            false
+        }
+    }
+}
+
+fn check_docker(ui: &mut Ui) -> bool {
+    // Check docker is installed
+    let installed = match Command::new("docker").arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stdout);
+            ui.check("Docker installed", &CheckStatus::Pass);
+            ui.info(&format!("  {}", ver.trim()));
+            true
+        }
+        _ => {
+            ui.check("Docker installed", &CheckStatus::Fail);
+            ui.info("  Install Docker: https://docs.docker.com/get-docker/");
+            return false;
+        }
+    };
+
+    // Check daemon is running
+    if installed {
+        match Command::new("docker").arg("info").output() {
+            Ok(output) if output.status.success() => {
+                ui.check("Docker daemon running", &CheckStatus::Pass);
+                true
+            }
+            _ => {
+                ui.check("Docker daemon running", &CheckStatus::Fail);
+                ui.info("  Start Docker daemon: sudo systemctl start docker");
+                false
+            }
+        }
+    } else {
+        false
+    }
+}
+
+fn check_disk_space(ui: &mut Ui, min_gb: u64) -> bool {
+    // Use df -BG . to get disk space in GB
+    match Command::new("df").args(["-BG", "."]).output() {
+        Ok(output) if output.status.success() => {
+            let text = String::from_utf8_lossy(&output.stdout);
+            // Parse the "Available" column (4th field of 2nd line)
+            if let Some(line) = text.lines().nth(1) {
+                let fields: Vec<&str> = line.split_whitespace().collect();
+                if fields.len() >= 4 {
+                    let avail_str = fields[3].trim_end_matches('G');
+                    if let Ok(avail) = avail_str.parse::<u64>() {
+                        if avail >= min_gb {
+                            ui.check(&format!("Disk space (>= {}GB)", min_gb), &CheckStatus::Pass);
+                            ui.info(&format!("  {}GB available", avail));
+                            return true;
+                        } else {
+                            ui.check(&format!("Disk space (>= {}GB)", min_gb), &CheckStatus::Fail);
+                            ui.info(&format!(
+                                "  Only {}GB available, need at least {}GB",
+                                avail, min_gb
+                            ));
+                            ui.info("  Cleanup: docker system prune -a, cargo clean, rm -rf /tmp/ephemeralml-*");
+                            return false;
+                        }
+                    }
+                }
+            }
+            ui.check(&format!("Disk space (>= {}GB)", min_gb), &CheckStatus::Pass);
+            ui.info("  (could not parse df output, assuming OK)");
+            true
+        }
+        _ => {
+            ui.check(&format!("Disk space (>= {}GB)", min_gb), &CheckStatus::Pass);
+            ui.info("  (df not available, assuming OK)");
+            true
+        }
+    }
+}
+
+fn check_env_file(ui: &mut Ui, project_dir: &Path) {
+    let path = project_dir.join(".env.gcp");
+    if path.exists() {
+        ui.check(".env.gcp file", &CheckStatus::Pass);
+    } else {
+        ui.check(".env.gcp file", &CheckStatus::Skip);
+        ui.info("  Optional: create .env.gcp with EPHEMERALML_GCP_PROJECT=your-project");
+    }
+}
+
+fn check_project_set(ui: &mut Ui, project_dir: &Path) -> bool {
+    // Check env var first
+    if let Ok(v) = std::env::var("EPHEMERALML_GCP_PROJECT") {
+        if !v.is_empty() {
+            ui.check("GCP project ID", &CheckStatus::Pass);
+            ui.info(&format!("  {}", v));
+            return true;
+        }
+    }
+    // Check .env.gcp file
+    let vars = super::config::parse_env_file(&project_dir.join(".env.gcp"));
+    if let Some(v) = vars.get("EPHEMERALML_GCP_PROJECT") {
+        if !v.is_empty() {
+            ui.check("GCP project ID", &CheckStatus::Pass);
+            ui.info(&format!("  {} (from .env.gcp)", v));
+            return true;
+        }
+    }
+    ui.check("GCP project ID", &CheckStatus::Skip);
+    false
+}

--- a/client/src/gcp/mod.rs
+++ b/client/src/gcp/mod.rs
@@ -1,0 +1,395 @@
+pub mod commands;
+pub mod config;
+pub mod doctor;
+pub mod preflight;
+pub mod runner;
+
+#[cfg(test)]
+mod tests;
+
+use clap::{Parser, Subcommand};
+use config::GcpFlags;
+
+/// GCP deployment and management commands.
+#[derive(Parser)]
+pub struct GcpArgs {
+    #[command(subcommand)]
+    pub command: GcpCommand,
+}
+
+#[derive(Subcommand)]
+pub enum GcpCommand {
+    /// Run preflight checks (gcloud, docker, disk space, auth)
+    Doctor,
+
+    /// Initialize GCP configuration (generates .env.gcp)
+    Init(InitArgs),
+
+    /// One-time GCP infrastructure setup (APIs, Artifact Registry, service account)
+    Setup(SetupArgs),
+
+    /// Set up Cloud KMS keyring, WIP, and GCS bucket
+    SetupKms(SetupKmsArgs),
+
+    /// Encrypt, sign, and upload model to GCS
+    PackageModel(PackageModelArgs),
+
+    /// Build container and launch Confidential Space CVM
+    Deploy(DeployArgs),
+
+    /// Smoke test a deployed CVM (inference + receipt verify)
+    Verify(VerifyArgs),
+
+    /// Delete the Confidential Space CVM
+    Teardown(TeardownArgs),
+
+    /// Run full end-to-end pipeline (setup -> deploy -> verify -> teardown)
+    E2e(E2eArgs),
+
+    /// Run pre-release validation gate
+    ReleaseGate(ReleaseGateArgs),
+}
+
+// ---- Shared flags ----
+
+#[derive(Parser)]
+pub struct SharedArgs {
+    /// GCP project ID
+    #[arg(long)]
+    pub project: Option<String>,
+
+    /// GCP region (default: derived from zone, e.g. us-central1)
+    #[arg(long)]
+    pub region: Option<String>,
+
+    /// GCP zone (default: us-central1-a)
+    #[arg(long)]
+    pub zone: Option<String>,
+
+    /// Print command without executing (skips preflight checks)
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Verbose output (print resolved config values)
+    #[arg(long, short = 'v')]
+    pub verbose: bool,
+
+    /// Output structured JSON status on completion
+    #[arg(long)]
+    pub json: bool,
+}
+
+// ---- Per-subcommand args ----
+
+#[derive(Parser)]
+pub struct InitArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Non-interactive mode (read values from env vars / .env.gcp)
+    #[arg(long)]
+    pub non_interactive: bool,
+}
+
+#[derive(Parser)]
+pub struct SetupArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Firewall source CIDR ranges
+    #[arg(long)]
+    pub source_ranges: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct SetupKmsArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Container image digest for WIP binding (e.g. sha256:abc123...)
+    #[arg(long)]
+    pub image_digest: Option<String>,
+
+    /// Allow broad WIP binding (dev only, no image restriction)
+    #[arg(long)]
+    pub allow_broad_binding: bool,
+}
+
+#[derive(Parser)]
+pub struct PackageModelArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Path to local model directory
+    #[arg(long)]
+    pub model_dir: Option<String>,
+
+    /// GCS path prefix for model upload
+    #[arg(long)]
+    pub model_prefix: Option<String>,
+
+    /// Model identifier
+    #[arg(long)]
+    pub model_id: Option<String>,
+
+    /// Model version
+    #[arg(long, name = "model-version")]
+    pub model_version: Option<String>,
+
+    /// Model format (safetensors or gguf)
+    #[arg(long)]
+    pub model_format: Option<String>,
+
+    /// Cloud KMS key resource name
+    #[arg(long)]
+    pub kms_key: Option<String>,
+
+    /// GCS bucket name
+    #[arg(long)]
+    pub bucket: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct DeployArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Deploy with GPU (a3-highgpu-1g with H100 CC)
+    #[arg(long)]
+    pub gpu: bool,
+
+    /// Use debug image (SSH enabled)
+    #[arg(long)]
+    pub debug: bool,
+
+    /// Skip Docker build/push
+    #[arg(long)]
+    pub skip_build: bool,
+
+    /// Skip confirmations
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+
+    /// Custom container image tag
+    #[arg(long)]
+    pub tag: Option<String>,
+
+    /// Model source: local, gcs, or gcs-kms
+    #[arg(long)]
+    pub model_source: Option<String>,
+
+    /// Cloud KMS key resource name
+    #[arg(long)]
+    pub kms_key: Option<String>,
+
+    /// WIP audience for STS exchange
+    #[arg(long)]
+    pub wip_audience: Option<String>,
+
+    /// GCS bucket name
+    #[arg(long)]
+    pub bucket: Option<String>,
+
+    /// GCS path prefix for model
+    #[arg(long)]
+    pub model_prefix: Option<String>,
+
+    /// SHA-256 hash of plaintext model weights
+    #[arg(long)]
+    pub model_hash: Option<String>,
+
+    /// Ed25519 public key (hex) for model manifest verification
+    #[arg(long)]
+    pub model_signing_pubkey: Option<String>,
+
+    /// Model format (safetensors or gguf)
+    #[arg(long)]
+    pub model_format: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct VerifyArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Explicit IP address of the deployed CVM
+    #[arg(long)]
+    pub ip: Option<String>,
+
+    /// Target GPU instance name
+    #[arg(long)]
+    pub gpu: bool,
+
+    /// Skip audience pin check (dev only)
+    #[arg(long)]
+    pub allow_unpinned_audience: bool,
+}
+
+#[derive(Parser)]
+pub struct TeardownArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Target GPU instance name
+    #[arg(long)]
+    pub gpu: bool,
+
+    /// Skip confirmations
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+
+    /// Also delete the container image tag from Artifact Registry
+    #[arg(long)]
+    pub delete_image: bool,
+}
+
+#[derive(Parser)]
+pub struct E2eArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Use CPU-only mode (c3-standard-4 instead of a3-highgpu-1g)
+    #[arg(long)]
+    pub cpu_only: bool,
+
+    /// Skip KMS/WIP setup (reuse existing infra)
+    #[arg(long)]
+    pub skip_setup: bool,
+
+    /// Skip VM teardown at end
+    #[arg(long)]
+    pub skip_teardown: bool,
+
+    /// Path to local model directory
+    #[arg(long)]
+    pub model_dir: Option<String>,
+
+    /// Model format (safetensors or gguf)
+    #[arg(long)]
+    pub model_format: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct ReleaseGateArgs {
+    #[command(flatten)]
+    pub shared: SharedArgs,
+
+    /// Skip slow tests (fmt + clippy + unit only)
+    #[arg(long)]
+    pub quick: bool,
+}
+
+// ---- Helper to extract shared fields into GcpFlags ----
+
+fn shared_to_flags(s: &SharedArgs) -> GcpFlags {
+    GcpFlags {
+        project: s.project.clone(),
+        region: s.region.clone(),
+        zone: s.zone.clone(),
+        dry_run: s.dry_run,
+        verbose: s.verbose,
+        json: s.json,
+        ..Default::default()
+    }
+}
+
+// ---- Conversion helpers: subcommand args -> GcpFlags ----
+
+impl From<&InitArgs> for GcpFlags {
+    fn from(a: &InitArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.non_interactive = a.non_interactive;
+        f
+    }
+}
+
+impl From<&SetupArgs> for GcpFlags {
+    fn from(a: &SetupArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.source_ranges = a.source_ranges.clone();
+        f
+    }
+}
+
+impl From<&SetupKmsArgs> for GcpFlags {
+    fn from(a: &SetupKmsArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.allow_broad_binding = a.allow_broad_binding;
+        f.image_digest = a.image_digest.clone();
+        f
+    }
+}
+
+impl From<&PackageModelArgs> for GcpFlags {
+    fn from(a: &PackageModelArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.model_dir = a.model_dir.clone();
+        f.model_prefix = a.model_prefix.clone();
+        f.model_id = a.model_id.clone();
+        f.model_version = a.model_version.clone();
+        f.model_format = a.model_format.clone();
+        f.kms_key = a.kms_key.clone();
+        f.bucket = a.bucket.clone();
+        f
+    }
+}
+
+impl From<&DeployArgs> for GcpFlags {
+    fn from(a: &DeployArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.gpu = a.gpu;
+        f.debug = a.debug;
+        f.skip_build = a.skip_build;
+        f.yes = a.yes;
+        f.tag = a.tag.clone();
+        f.model_source = a.model_source.clone();
+        f.kms_key = a.kms_key.clone();
+        f.wip_audience = a.wip_audience.clone();
+        f.bucket = a.bucket.clone();
+        f.model_prefix = a.model_prefix.clone();
+        f.model_hash = a.model_hash.clone();
+        f.model_signing_pubkey = a.model_signing_pubkey.clone();
+        f.model_format = a.model_format.clone();
+        f
+    }
+}
+
+impl From<&VerifyArgs> for GcpFlags {
+    fn from(a: &VerifyArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.gpu = a.gpu;
+        f.ip = a.ip.clone();
+        f.allow_unpinned_audience = a.allow_unpinned_audience;
+        f
+    }
+}
+
+impl From<&TeardownArgs> for GcpFlags {
+    fn from(a: &TeardownArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.gpu = a.gpu;
+        f.yes = a.yes;
+        f.delete_image = a.delete_image;
+        f
+    }
+}
+
+impl From<&E2eArgs> for GcpFlags {
+    fn from(a: &E2eArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.cpu_only = a.cpu_only;
+        f.skip_setup = a.skip_setup;
+        f.skip_teardown = a.skip_teardown;
+        f.model_dir = a.model_dir.clone();
+        f.model_format = a.model_format.clone();
+        f
+    }
+}
+
+impl From<&ReleaseGateArgs> for GcpFlags {
+    fn from(a: &ReleaseGateArgs) -> Self {
+        let mut f = shared_to_flags(&a.shared);
+        f.quick = a.quick;
+        f
+    }
+}

--- a/client/src/gcp/preflight.rs
+++ b/client/src/gcp/preflight.rs
@@ -1,0 +1,72 @@
+use anyhow::{bail, Result};
+use std::process::Command;
+
+use super::config::GcpConfig;
+
+const MIN_DISK_GB: u64 = 20;
+
+/// Run preflight checks before executing a GCP command.
+///
+/// Called automatically before deploy, setup, setup-kms, package-model.
+/// Fails closed: any failure stops execution with a clear error.
+pub fn run_preflight(config: &GcpConfig) -> Result<()> {
+    check_disk_space(MIN_DISK_GB)?;
+    check_gcloud_auth()?;
+    config.require_project()?;
+    Ok(())
+}
+
+fn check_disk_space(min_gb: u64) -> Result<()> {
+    let output = Command::new("df")
+        .args(["-BG", "."])
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to check disk space (df not available): {}", e))?;
+    if !output.status.success() {
+        bail!(
+            "Disk space check failed: df exited with code {}",
+            output.status.code().unwrap_or(-1)
+        );
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let line = text
+        .lines()
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("Disk space check failed: could not parse df output"))?;
+    let fields: Vec<&str> = line.split_whitespace().collect();
+    if fields.len() < 4 {
+        bail!("Disk space check failed: unexpected df output format");
+    }
+    let avail_str = fields[3].trim_end_matches('G');
+    let avail: u64 = avail_str.parse().map_err(|_| {
+        anyhow::anyhow!(
+            "Disk space check failed: could not parse '{}' as GB",
+            avail_str
+        )
+    })?;
+    if avail < min_gb {
+        bail!(
+            "Insufficient disk space: {}GB available, need at least {}GB.\n\
+             Cleanup hints:\n  \
+             - docker system prune -a   (remove unused images/containers)\n  \
+             - cargo clean               (remove target/ build artifacts)\n  \
+             - rm -rf /tmp/ephemeralml-* (remove temp inference files)",
+            avail,
+            min_gb
+        );
+    }
+    Ok(())
+}
+
+fn check_gcloud_auth() -> Result<()> {
+    match Command::new("gcloud")
+        .args(["auth", "print-access-token"])
+        .output()
+    {
+        Ok(output) if output.status.success() => Ok(()),
+        _ => bail!(
+            "gcloud is not authenticated. Run:\n  \
+             gcloud auth login\n  \
+             gcloud auth application-default login"
+        ),
+    }
+}

--- a/client/src/gcp/runner.rs
+++ b/client/src/gcp/runner.rs
@@ -1,0 +1,176 @@
+use anyhow::{bail, Context, Result};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use super::config::GcpConfig;
+
+/// Runs GCP bash scripts with config-derived environment variables.
+pub struct ScriptRunner {
+    /// Path to the project root (contains `scripts/gcp/`).
+    project_dir: PathBuf,
+}
+
+impl ScriptRunner {
+    pub fn new(project_dir: PathBuf) -> Self {
+        Self { project_dir }
+    }
+
+    /// Resolve the full path to a script in `scripts/gcp/`.
+    pub fn script_path(&self, script_name: &str) -> PathBuf {
+        self.project_dir
+            .join("scripts")
+            .join("gcp")
+            .join(script_name)
+    }
+
+    /// Run a GCP script, passing args and injecting config as env vars.
+    ///
+    /// stdout/stderr are inherited (streamed to terminal).
+    /// If `config.dry_run` is true, prints the command without executing.
+    pub fn run(
+        &self,
+        script_name: &str,
+        args: &[&str],
+        config: &GcpConfig,
+        dry_run: bool,
+    ) -> Result<()> {
+        let path = self.script_path(script_name);
+        if !path.exists() {
+            bail!(
+                "Script not found: {}. Expected at {}",
+                script_name,
+                path.display()
+            );
+        }
+
+        if dry_run {
+            let args_display = if args.is_empty() {
+                String::new()
+            } else {
+                format!(" {}", args.join(" "))
+            };
+            println!("[dry-run] bash {}{}", path.display(), args_display);
+            println!("[dry-run] Environment:");
+            for (k, v) in Self::config_env(config) {
+                if !v.is_empty() {
+                    println!("[dry-run]   {}={}", k, v);
+                }
+            }
+            return Ok(());
+        }
+
+        let mut cmd = Command::new("bash");
+        cmd.arg(&path);
+        cmd.args(args);
+        cmd.stdout(Stdio::inherit());
+        cmd.stderr(Stdio::inherit());
+        cmd.current_dir(&self.project_dir);
+
+        // Inject config as environment variables
+        for (key, value) in Self::config_env(config) {
+            cmd.env(key, value);
+        }
+
+        let status = cmd
+            .status()
+            .with_context(|| format!("Failed to execute {}", script_name))?;
+
+        if !status.success() {
+            let code = status.code().unwrap_or(-1);
+            bail!("{} exited with code {}", script_name, code);
+        }
+
+        Ok(())
+    }
+
+    /// Build environment variable pairs from GcpConfig.
+    fn config_env(config: &GcpConfig) -> Vec<(&'static str, String)> {
+        let mut env = vec![
+            ("EPHEMERALML_GCP_PROJECT", config.project.clone()),
+            ("EPHEMERALML_GCP_REGION", config.region.clone()),
+            ("EPHEMERALML_GCP_ZONE", config.zone.clone()),
+            ("EPHEMERALML_GCS_BUCKET", config.bucket.clone()),
+            ("EPHEMERALML_GCP_MODEL_PREFIX", config.model_prefix.clone()),
+            ("EPHEMERALML_MODEL_SOURCE", config.model_source.clone()),
+            ("EPHEMERALML_MODEL_FORMAT", config.model_format.clone()),
+        ];
+        if let Some(ref v) = config.kms_key {
+            env.push(("EPHEMERALML_GCP_KMS_KEY", v.clone()));
+            env.push(("GCP_KMS_KEY", v.clone()));
+        }
+        if let Some(ref v) = config.wip_audience {
+            env.push(("EPHEMERALML_GCP_WIP_AUDIENCE", v.clone()));
+            env.push(("GCP_WIP_AUDIENCE", v.clone()));
+        }
+        if let Some(ref v) = config.model_hash {
+            env.push(("EPHEMERALML_EXPECTED_MODEL_HASH", v.clone()));
+        }
+        if let Some(ref v) = config.model_signing_pubkey {
+            env.push(("EPHEMERALML_MODEL_SIGNING_PUBKEY", v.clone()));
+        }
+        if let Some(ref v) = config.source_ranges {
+            env.push(("EPHEMERALML_FIREWALL_SOURCE_RANGES", v.clone()));
+        }
+        env.push(("GCP_BUCKET", config.bucket.clone()));
+        env
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_project_dir() -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "ephemeralml_runner_test_{}_{}",
+            std::process::id(),
+            nanos
+        ));
+        std::fs::create_dir_all(dir.join("scripts").join("gcp")).unwrap();
+        dir
+    }
+
+    #[test]
+    fn script_path_resolves_correctly() {
+        let dir = test_project_dir();
+        let runner = ScriptRunner::new(dir.clone());
+        let path = runner.script_path("deploy.sh");
+        assert_eq!(path, dir.join("scripts").join("gcp").join("deploy.sh"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn missing_script_returns_error() {
+        let dir = test_project_dir();
+        let runner = ScriptRunner::new(dir.clone());
+        let config = GcpConfig::resolve(&super::super::config::GcpFlags::default(), &dir).unwrap();
+        let err = runner.run("nonexistent.sh", &[], &config, false);
+        assert!(err.is_err());
+        assert!(err.unwrap_err().to_string().contains("Script not found"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn dry_run_does_not_execute() {
+        let dir = test_project_dir();
+        // Create a script that would fail if executed
+        let script_path = dir.join("scripts").join("gcp").join("fail.sh");
+        std::fs::write(&script_path, "#!/bin/bash\nexit 1").unwrap();
+
+        let runner = ScriptRunner::new(dir.clone());
+        let flags = super::super::config::GcpFlags {
+            project: Some("test-proj".to_string()),
+            dry_run: true,
+            ..Default::default()
+        };
+        let config = GcpConfig::resolve(&flags, &dir).unwrap();
+        // dry_run=true should return Ok even though script would fail
+        let result = runner.run("fail.sh", &[], &config, true);
+        assert!(result.is_ok());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/client/src/gcp/tests.rs
+++ b/client/src/gcp/tests.rs
@@ -1,0 +1,452 @@
+use super::commands::build_setup_kms_args;
+use super::config::{parse_env_file, region_from_zone, GcpConfig, GcpFlags};
+use super::runner::ScriptRunner;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn temp_dir(suffix: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "ephemeralml_gcp_test_{}_{}_{}",
+        std::process::id(),
+        nanos,
+        suffix
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+// ---- Config resolution tests ----
+
+#[test]
+fn config_flags_override_file() {
+    let dir = temp_dir("flags_override");
+    let env_path = dir.join(".env.gcp");
+    let mut f = std::fs::File::create(&env_path).unwrap();
+    writeln!(f, "EPHEMERALML_GCP_PROJECT=file-project").unwrap();
+    writeln!(f, "EPHEMERALML_GCP_ZONE=file-zone").unwrap();
+    writeln!(f, "EPHEMERALML_GCS_BUCKET=file-bucket").unwrap();
+    drop(f);
+
+    let flags = GcpFlags {
+        project: Some("flag-project".to_string()),
+        zone: Some("flag-zone".to_string()),
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    assert_eq!(config.project, "flag-project");
+    assert_eq!(config.zone, "flag-zone");
+    assert!(!config.bucket.is_empty());
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn config_defaults_when_nothing_set() {
+    let dir = temp_dir("defaults");
+    let flags = GcpFlags::default();
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    assert_eq!(config.zone, "us-central1-a");
+    assert_eq!(config.region, "us-central1");
+    assert_eq!(config.bucket, "ephemeralml-models");
+    assert_eq!(config.model_prefix, "models/minilm");
+    assert_eq!(config.model_source, "local");
+    assert_eq!(config.model_format, "safetensors");
+    assert!(!config.gpu);
+    assert!(!config.debug);
+    assert!(!config.dry_run);
+    assert!(!config.verbose);
+    assert!(!config.json);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn config_boolean_flags_propagate() {
+    let dir = temp_dir("booleans");
+    let flags = GcpFlags {
+        gpu: true,
+        debug: true,
+        skip_build: true,
+        yes: true,
+        dry_run: true,
+        delete_image: true,
+        allow_unpinned_audience: true,
+        cpu_only: true,
+        verbose: true,
+        json: true,
+        quick: true,
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    assert!(config.gpu);
+    assert!(config.debug);
+    assert!(config.skip_build);
+    assert!(config.yes);
+    assert!(config.dry_run);
+    assert!(config.delete_image);
+    assert!(config.allow_unpinned_audience);
+    assert!(config.cpu_only);
+    assert!(config.verbose);
+    assert!(config.json);
+    assert!(config.quick);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---- .env.gcp parser tests ----
+
+#[test]
+fn env_file_parses_comments_and_empty_lines() {
+    let dir = temp_dir("parser_comments");
+    let path = dir.join(".env.gcp");
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "# This is a comment").unwrap();
+    writeln!(f).unwrap();
+    writeln!(f, "KEY1=value1").unwrap();
+    writeln!(f, "  # indented comment").unwrap();
+    writeln!(f, "KEY2=value2").unwrap();
+    drop(f);
+
+    let vars = parse_env_file(&path);
+    assert_eq!(vars.len(), 2);
+    assert_eq!(vars["KEY1"], "value1");
+    assert_eq!(vars["KEY2"], "value2");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn env_file_strips_quotes() {
+    let dir = temp_dir("parser_quotes");
+    let path = dir.join(".env.gcp");
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "A=\"double-quoted\"").unwrap();
+    writeln!(f, "B='single-quoted'").unwrap();
+    writeln!(f, "C=no-quotes").unwrap();
+    drop(f);
+
+    let vars = parse_env_file(&path);
+    assert_eq!(vars["A"], "double-quoted");
+    assert_eq!(vars["B"], "single-quoted");
+    assert_eq!(vars["C"], "no-quotes");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn env_file_handles_spaces() {
+    let dir = temp_dir("parser_spaces");
+    let path = dir.join(".env.gcp");
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "  KEY  =  value  ").unwrap();
+    drop(f);
+
+    let vars = parse_env_file(&path);
+    assert_eq!(vars["KEY"], "value");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn env_file_export_prefix_parsed() {
+    let dir = temp_dir("parser_export");
+    let path = dir.join(".env.gcp");
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "export EPHEMERALML_GCP_PROJECT=\"my-project\"").unwrap();
+    writeln!(f, "export EPHEMERALML_GCP_ZONE=\"us-west1-b\"").unwrap();
+    drop(f);
+
+    let vars = parse_env_file(&path);
+    assert_eq!(vars["EPHEMERALML_GCP_PROJECT"], "my-project");
+    assert_eq!(vars["EPHEMERALML_GCP_ZONE"], "us-west1-b");
+    // Must NOT store as "export EPHEMERALML_GCP_PROJECT"
+    assert!(!vars.contains_key("export EPHEMERALML_GCP_PROJECT"));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn env_file_mixed_export_and_plain() {
+    let dir = temp_dir("parser_mixed");
+    let path = dir.join(".env.gcp");
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "# Generated by init_gcp.sh").unwrap();
+    writeln!(f, "export EPHEMERALML_GCP_PROJECT=\"proj-a\"").unwrap();
+    writeln!(f, "PLAIN_KEY=plain-value").unwrap();
+    writeln!(f, "export QUOTED='single-q'").unwrap();
+    drop(f);
+
+    let vars = parse_env_file(&path);
+    assert_eq!(vars["EPHEMERALML_GCP_PROJECT"], "proj-a");
+    assert_eq!(vars["PLAIN_KEY"], "plain-value");
+    assert_eq!(vars["QUOTED"], "single-q");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn env_file_export_config_resolution() {
+    let dir = temp_dir("export_resolve");
+    let path = dir.join(".env.gcp");
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "export EPHEMERALML_GCP_PROJECT=\"from-init-script\"").unwrap();
+    writeln!(f, "export EPHEMERALML_GCP_ZONE=\"europe-west4-b\"").unwrap();
+    drop(f);
+
+    let flags = GcpFlags::default();
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    // Should successfully resolve from export-prefixed .env.gcp
+    assert_eq!(config.project, "from-init-script");
+    assert_eq!(config.zone, "europe-west4-b");
+    assert_eq!(config.region, "europe-west4");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---- Region derivation tests ----
+
+#[test]
+fn region_from_zone_standard_zones() {
+    assert_eq!(region_from_zone("us-central1-a"), "us-central1");
+    assert_eq!(region_from_zone("us-central1-f"), "us-central1");
+    assert_eq!(region_from_zone("europe-west4-b"), "europe-west4");
+    assert_eq!(region_from_zone("asia-southeast1-c"), "asia-southeast1");
+    assert_eq!(region_from_zone("me-central1-a"), "me-central1");
+}
+
+#[test]
+fn region_from_zone_edge_cases() {
+    // No suffix letter
+    assert_eq!(region_from_zone("us-central1"), "us-central1");
+    // No hyphen at all
+    assert_eq!(region_from_zone("nohyphen"), "nohyphen");
+}
+
+#[test]
+fn config_region_derived_from_zone() {
+    let dir = temp_dir("region_derived");
+    let flags = GcpFlags {
+        zone: Some("us-west1-b".to_string()),
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    assert_eq!(config.region, "us-west1");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn config_region_flag_overrides_zone_derivation() {
+    let dir = temp_dir("region_override");
+    let flags = GcpFlags {
+        zone: Some("us-west1-b".to_string()),
+        region: Some("europe-west4".to_string()),
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    assert_eq!(config.region, "europe-west4");
+    assert_eq!(config.zone, "us-west1-b");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---- ScriptRunner tests ----
+
+#[test]
+fn runner_script_path_resolution() {
+    let dir = temp_dir("runner_path");
+    std::fs::create_dir_all(dir.join("scripts").join("gcp")).unwrap();
+    let runner = ScriptRunner::new(dir.clone());
+
+    assert_eq!(
+        runner.script_path("deploy.sh"),
+        dir.join("scripts/gcp/deploy.sh")
+    );
+    assert_eq!(
+        runner.script_path("setup_kms.sh"),
+        dir.join("scripts/gcp/setup_kms.sh")
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn runner_missing_script_fails() {
+    let dir = temp_dir("runner_missing");
+    std::fs::create_dir_all(dir.join("scripts").join("gcp")).unwrap();
+    let runner = ScriptRunner::new(dir.clone());
+
+    let config = GcpConfig::resolve(&GcpFlags::default(), &dir).unwrap();
+    let err = runner.run("does_not_exist.sh", &[], &config, false);
+    assert!(err.is_err());
+    let msg = err.unwrap_err().to_string();
+    assert!(msg.contains("Script not found"), "got: {}", msg);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn runner_dry_run_succeeds_for_failing_script() {
+    let dir = temp_dir("runner_dryrun");
+    let scripts_dir = dir.join("scripts").join("gcp");
+    std::fs::create_dir_all(&scripts_dir).unwrap();
+    std::fs::write(scripts_dir.join("fail.sh"), "#!/bin/bash\nexit 42").unwrap();
+
+    let runner = ScriptRunner::new(dir.clone());
+    let config = GcpConfig::resolve(&GcpFlags::default(), &dir).unwrap();
+    let result = runner.run("fail.sh", &[], &config, true);
+    assert!(result.is_ok());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn runner_executes_successful_script() {
+    let dir = temp_dir("runner_success");
+    let scripts_dir = dir.join("scripts").join("gcp");
+    std::fs::create_dir_all(&scripts_dir).unwrap();
+    std::fs::write(scripts_dir.join("ok.sh"), "#!/bin/bash\nexit 0").unwrap();
+
+    let runner = ScriptRunner::new(dir.clone());
+    let config = GcpConfig::resolve(&GcpFlags::default(), &dir).unwrap();
+    let result = runner.run("ok.sh", &[], &config, false);
+    assert!(result.is_ok());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn runner_reports_nonzero_exit() {
+    let dir = temp_dir("runner_nonzero");
+    let scripts_dir = dir.join("scripts").join("gcp");
+    std::fs::create_dir_all(&scripts_dir).unwrap();
+    std::fs::write(scripts_dir.join("fail.sh"), "#!/bin/bash\nexit 7").unwrap();
+
+    let runner = ScriptRunner::new(dir.clone());
+    let config = GcpConfig::resolve(&GcpFlags::default(), &dir).unwrap();
+    let err = runner.run("fail.sh", &[], &config, false);
+    assert!(err.is_err());
+    let msg = err.unwrap_err().to_string();
+    assert!(msg.contains("exited with code 7"), "got: {}", msg);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---- require_project tests ----
+
+#[test]
+fn require_project_fails_when_empty() {
+    let dir = temp_dir("require_empty");
+    let config = GcpConfig::resolve(&GcpFlags::default(), &dir).unwrap();
+    assert!(config.require_project().is_err());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn require_project_ok_when_set() {
+    let dir = temp_dir("require_set");
+    let flags = GcpFlags {
+        project: Some("my-proj".to_string()),
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    assert_eq!(config.require_project().unwrap(), "my-proj");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---- setup-kms arg construction tests (via build_setup_kms_args) ----
+
+#[test]
+fn setup_kms_args_uses_region_not_zone() {
+    let dir = temp_dir("kms_region");
+    let flags = GcpFlags {
+        project: Some("test-proj".to_string()),
+        zone: Some("europe-west4-b".to_string()),
+        allow_broad_binding: true,
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    let args = build_setup_kms_args(&config).unwrap();
+    // First positional = project, second = region (NOT zone)
+    assert_eq!(args[0], "test-proj");
+    assert_eq!(args[1], "europe-west4"); // derived region, not "europe-west4-b"
+    assert_eq!(args[2], "--allow-broad-binding");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn setup_kms_args_rejects_missing_mode() {
+    let dir = temp_dir("kms_no_mode");
+    let flags = GcpFlags {
+        project: Some("test-proj".to_string()),
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    let err = build_setup_kms_args(&config);
+    assert!(err.is_err());
+    let msg = err.unwrap_err().to_string();
+    assert!(
+        msg.contains("--image-digest") && msg.contains("--allow-broad-binding"),
+        "expected guidance in error, got: {}",
+        msg
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn setup_kms_args_with_broad_binding() {
+    let dir = temp_dir("kms_broad");
+    let flags = GcpFlags {
+        project: Some("my-proj".to_string()),
+        allow_broad_binding: true,
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    let args = build_setup_kms_args(&config).unwrap();
+    assert_eq!(
+        args,
+        vec!["my-proj", "us-central1", "--allow-broad-binding"]
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn setup_kms_args_with_image_digest() {
+    let dir = temp_dir("kms_digest");
+    let flags = GcpFlags {
+        project: Some("my-proj".to_string()),
+        zone: Some("us-west1-b".to_string()),
+        image_digest: Some("sha256:deadbeef".to_string()),
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    let args = build_setup_kms_args(&config).unwrap();
+    assert_eq!(args, vec!["my-proj", "us-west1", "sha256:deadbeef"]);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---- dry-run preflight behavior test ----
+
+#[test]
+fn dry_run_does_not_require_project() {
+    // With dry_run=true, preflight should not block on missing project.
+    // We verify that GcpConfig resolves even with empty project + dry_run.
+    let dir = temp_dir("dryrun_no_project");
+    let flags = GcpFlags {
+        dry_run: true,
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    assert!(config.dry_run);
+    assert!(config.project.is_empty());
+    // require_project would fail, but preflight_or_dry_run skips it
+    assert!(config.require_project().is_err());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---- JSON output contract test ----
+
+#[test]
+fn json_status_format() {
+    // Verify the JSON status string format
+    let dir = temp_dir("json_format");
+    let flags = GcpFlags {
+        project: Some("p".to_string()),
+        json: true,
+        ..Default::default()
+    };
+    let config = GcpConfig::resolve(&flags, &dir).unwrap();
+    assert!(config.json);
+    // The json_status function is in commands.rs; here we just verify
+    // that the config flag propagates correctly.
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -19,6 +19,7 @@ pub mod attestation_bridge;
 pub mod attestation_verifier;
 pub mod error;
 pub mod freshness;
+pub mod gcp;
 pub mod model_validation;
 pub mod policy;
 pub mod secure_client;


### PR DESCRIPTION
## Summary
- Adds `ephemeralml gcp <subcommand>` CLI wrapping all 10 GCP deployment scripts
- Config resolution: CLI flags > env vars > `.env.gcp` > defaults
- Fail-closed preflight (disk, auth, project) with `--dry-run` bypass
- `setup-kms` validates `--image-digest` or `--allow-broad-binding` before script invocation
- `.env.gcp` parser handles `export KEY="value"` format from `init_gcp.sh`
- Region derivation from zone; `setup-kms` passes region (not zone) to script
- 88 tests, clippy clean, zero warnings

## Test plan
- [x] `cargo test -p ephemeral-ml-client` (88 pass)
- [x] `cargo clippy --tests -D warnings` (clean)
- [ ] `ephemeralml gcp doctor` on target machine
- [ ] `ephemeralml gcp deploy --dry-run` prints correct command
- [ ] `ephemeralml gcp setup-kms` without mode flag shows typed error