### PR TITLE
chore(deps): migrate reqwest 0.12 → 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,7 +1776,7 @@ dependencies = [
  "openssl",
  "proptest",
  "rand 0.8.5",
- "reqwest 0.13.2",
+ "reqwest",
  "safetensors 0.7.0",
  "serde",
  "serde_bytes",
@@ -1862,7 +1862,7 @@ dependencies = [
  "openssl",
  "proptest",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest",
  "rsa",
  "safetensors 0.7.0",
  "serde",
@@ -1930,7 +1930,7 @@ dependencies = [
  "ephemeral-ml-common",
  "hex",
  "rand 0.8.5",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -2803,22 +2803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,7 +2819,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3368,23 +3352,6 @@ dependencies = [
  "mime",
  "spin 0.9.8",
  "version_check",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -4049,7 +4016,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4087,7 +4054,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4277,46 +4244,6 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower 0.5.3",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -4345,6 +4272,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -5196,16 +5124,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -40,7 +40,7 @@ ed25519-dalek = { workspace = true }
 aws-sdk-kms = { version = "1.100.0", optional = true }
 aws-config = { version = "1.8.14", optional = true }
 byteorder = "1.5.0"
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { version = "0.13", features = ["json", "form"], optional = true }
 base64 = "0.22"
 # Enclave always needs transport mock (to accept non-TEE client attestations) and tcp.
 confidential-ml-transport = { workspace = true, features = ["mock", "tcp"] }


### PR DESCRIPTION
## Summary

- Upgrade the last workspace member (`ephemeral-ml-enclave`) from reqwest 0.12 to 0.13, unifying the workspace on a single reqwest version (0.13.2)
- Add the `form` crate feature required by reqwest 0.13 for `.form()` usage in GCP KMS clients
- Remove transitive deps that are no longer needed: `native-tls`, `hyper-tls`, `tokio-native-tls`

Supersedes the failed Dependabot PR #38 which only bumped the version without adding the new `form` feature flag.

## Breaking changes encountered

reqwest 0.13 introduced these breaking changes ([changelog](https://github.com/seanmonstar/reqwest/blob/master/CHANGELOG.md#v0130)):

| Change | Impact on this repo |
|--------|-------------------|
| `query` and `form` are now opt-in crate features (disabled by default) | **Root cause of #38 failures.** `gcp_kms_client.rs` and `cs_kms_client.rs` call `.form()` for STS token exchange. Fixed by adding `"form"` to the feature list. |
| `rustls` is now the default TLS backend (was `native-tls`) | No impact — this project already used rustls via `hyper-rustls`. Removes `native-tls`/`hyper-tls`/`tokio-native-tls` from the dep tree. |
| `rustls` crypto provider defaults to aws-lc instead of ring | No impact — aws-lc-rs was already a transitive dep. |
| `rustls-tls` feature renamed to `rustls` | Not used directly by this project. |
| `rustls-platform-verifier` used by default for root certs | No impact — platform verifier was already pulled in. |
| Long-deprecated features removed (`trust-dns`, etc.) | Not used by this project. |

## Code-level migration notes

Only one file changed (`enclave/Cargo.toml`):

```diff
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { version = "0.13", features = ["json", "form"], optional = true }
```

The `form` feature is needed because `gcp_kms_client.rs` and `cs_kms_client.rs` use `RequestBuilder::form()` for STS token exchange requests. In reqwest 0.12, `.form()` was always available; in 0.13, it requires the `form` feature which pulls in `serde_urlencoded`.

No Rust source code changes were required. The reqwest 0.13 API is source-compatible for all usage patterns in this codebase.

## Runtime behavior differences

- TLS backend is now rustls (was native-tls for enclave). Since the client and verifier-api were already on 0.13/rustls, this aligns the enclave.
- `native-tls` (OpenSSL-backed on Linux) is removed from the dependency tree, reducing the attack surface by ~3 transitive crates.

## Test plan

- [x] `cargo check --workspace --features mock` — compiles clean
- [x] `cargo check --no-default-features --features gcp -p ephemeral-ml-enclave` — compiles clean
- [x] `cargo check --no-default-features --features gcp -p ephemeral-ml-client` — compiles clean
- [x] `cargo test --workspace --features mock` — all tests pass
- [x] `cargo test --no-default-features --features gcp -p ephemeral-ml-enclave` — all tests pass (incl. GCP KMS mock HTTP tests)
- [x] `cargo clippy --workspace --features mock -- -D warnings` — clean
- [x] `cargo clippy --no-default-features --features gcp -p ephemeral-ml-enclave -- -D warnings` — clean
- [x] `cargo clippy --no-default-features --features gcp -p ephemeral-ml-client -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)